### PR TITLE
Add tariff_measure_number to measures.

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -425,6 +425,10 @@ class Measure < Sequel::Model
       where(goods_nomenclature_item_id: goods_nomenclature_item_id)
     end
 
+    def with_tariff_measure_number(tariff_measure_number)
+      where(tariff_measure_number: tariff_measure_number)
+    end
+
     def with_geographical_area(area)
       where(geographical_area: area)
     end

--- a/db/migrate/20121009120028_add_tariff_measure_number.rb
+++ b/db/migrate/20121009120028_add_tariff_measure_number.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table :measures do
+      add_column :tariff_measure_number, String, size: 10
+    end
+  end
+
+  down do
+    alter_table :measures do
+      drop_column :tariff_measure_number
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1081,6 +1081,7 @@ Sequel.migration do
       column :created_at, "datetime"
       column :updated_at, "datetime"
       column :national, "tinyint(1)"
+      column :tariff_measure_number, "varchar(10)"
 
       index [:additional_code_sid], :name=>:index_measures_on_additional_code_sid
       index [:geographical_area_sid], :name=>:index_measures_on_geographical_area_sid
@@ -1532,6 +1533,7 @@ Sequel.migration do
     self[:schema_migrations].insert(:filename => "20121008175409_add_abbreviation_to_duty_expression.rb")
     self[:schema_migrations].insert(:filename => "20121008181507_manual_add_abbreviations.rb")
     self[:schema_migrations].insert(:filename => "20121009092643_change_asx_to_asv.rb")
+    self[:schema_migrations].insert(:filename => "20121009120028_add_tariff_measure_number.rb")
 
     create_table(:search_references) do
       primary_key :id, :type=>"int(11)"

--- a/lib/chief_transformer/candidate_measure.rb
+++ b/lib/chief_transformer/candidate_measure.rb
@@ -96,6 +96,7 @@ class ChiefTransformer
       self.measure_type = mfcm.measure_type_adco.measure_type_id.presence || mfcm.msr_type
       self.additional_code = mfcm.measure_type_adco.adtnl_cd
       self.additional_code_type = mfcm.measure_type_adco.adtnl_cd_type_id
+      self.tariff_measure_number = mfcm.tar_msr_no
     end
 
     def assign_dates

--- a/lib/chief_transformer/interactions/tame_interaction.rb
+++ b/lib/chief_transformer/interactions/tame_interaction.rb
@@ -12,6 +12,7 @@ class ChiefTransformer
         Measure.national
                .with_measure_type(tame.measure_type)
                .valid_before(tame.fe_tsmp)
+               .with_tariff_measure_number(tame.tar_msr_no)
                .not_terminated
                .each do |measure|
           MeasureLogger.log(measure, :update, {validity_end_date: tame.fe_tsmp}, tame, tame.origin)
@@ -42,6 +43,7 @@ class ChiefTransformer
       def update_or_create_tame_components_for(tame)
         Measure.with_measure_type(tame.measure_type)
                .valid_from(tame.fe_tsmp)
+               .with_tariff_measure_number(tame.tar_msr_no)
                .eager(:measure_components)
                .all
                .each do |measure|

--- a/lib/chief_transformer/interactions/tame_update.rb
+++ b/lib/chief_transformer/interactions/tame_update.rb
@@ -8,6 +8,7 @@ class ChiefTransformer
           # Find all Measures that fall into record validity date range
           # and set their end dates to le_tsmp.
           Measure.with_measure_type(record.measure_type)
+                 .with_tariff_measure_number(record.tar_msr_no)
                  .valid_since(record.fe_tsmp)
                  .valid_to(record.le_tsmp)
                  .each do |measure|


### PR DESCRIPTION
This is needed to process TAME record operations for prohibition and
restriction measures correctly. We need to operate on measures with
correct tariff_measure_number only.
