### PR TITLE
Match whitespace separated commodity codes.

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -32,7 +32,7 @@ class SearchService
                 when /^[0-9]{10}$/
                   Commodity.actual.by_code(query_string).declarable.first.presence ||
                   Heading.actual.by_declarable_code(query_string).declarable.first.presence
-                when /^\d{2}\s{1}\d{2}\s{1}\d{2}\s{1}\d{2}\s{1}\d{2}$/ # matches commodity codes in format of ## ## ## ## ##
+                when /^\d{2}\s*\d{2}\s*\d{2}\s*\d{2}\s*\d{2}$/
                   Commodity.actual.by_code(query_string.gsub(/\s+/, '')).declarable.first.presence ||
                   Heading.actual.by_declarable_code(query_string.gsub(/\s+/, '')).declarable.first.presence
                 when /^[0-9]{11,12}$/

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -120,6 +120,19 @@ describe SearchService do
         result.should match_json_expression commodity_pattern
       end
 
+      it 'returns endpoint and identifier if provided with 10 digits separated by whitespace of varying length' do
+        code =  [commodity.goods_nomenclature_item_id[0..1],
+                 commodity.goods_nomenclature_item_id[2..3]].join("")
+        code << [commodity.goods_nomenclature_item_id[4..5],
+                 commodity.goods_nomenclature_item_id[6..7]].join("     ")
+        code << "  " << commodity.goods_nomenclature_item_id[8..9]
+
+        result = SearchService.new(q: code,
+                                   as_of: Date.today).to_json
+
+        result.should match_json_expression commodity_pattern
+      end
+
       it 'returns endpoint and identifier if provided with matching 12 symbol commodity code' do
         result = SearchService.new(q: commodity.goods_nomenclature_item_id + commodity.producline_suffix,
                                    as_of: Date.today).to_json


### PR DESCRIPTION
The aim is to make exact search work with commodity codes formatted as say "0101 2100 00" as in the example scenarios.
