### PR TITLE
Add monetary unit abbreviations.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,12 +48,13 @@ group :test do
   gem "forgery"
   gem "json_expressions"
   gem "rspec-rails"
-  gem "shoulda-matchers"
+  gem "shoulda-matchers", git: "https://github.com/thoughtbot/shoulda-matchers.git",
+                          ref: "9e1188eea6" # TODO change to stable version when next release comes out
+  gem "mocha", require: false
   gem "simplecov"
   gem "simplecov-rcov"
   gem "webmock"
   gem "vcr"
-  gem "mocha", require: false
 end
 
 group :router do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,15 @@ GIT
     nulogy-sequel-rails (0.3.7)
       sequel (~> 3.28)
 
+GIT
+  remote: https://github.com/thoughtbot/shoulda-matchers.git
+  revision: 9e1188eea68c47d9a56ce6280e45027da6187ab1
+  ref: 9e1188eea6
+  specs:
+    shoulda-matchers (1.4.1)
+      activesupport (>= 3.0.0)
+      bourne (~> 1.1.2)
+
 GEM
   remote: https://rubygems.org/
   remote: https://gems.gemfury.com/vo6ZrmjBQu5szyywDszE/
@@ -45,6 +54,8 @@ GEM
       mime-types
       xml-simple
     bootstrap-sass (2.1.0.0)
+    bourne (1.1.2)
+      mocha (= 0.10.5)
     brakeman (1.7.0)
       activesupport
       erubis (~> 2.6)
@@ -110,7 +121,7 @@ GEM
     metaclass (0.0.1)
     method_source (0.8)
     mime-types (1.19)
-    mocha (0.12.4)
+    mocha (0.10.5)
       metaclass (~> 0.0.1)
     multi_json (1.3.6)
     mysql2 (0.3.11)
@@ -192,8 +203,6 @@ GEM
       tilt (~> 1.3)
     sequel (3.39.0)
     sexp_processor (3.2.0)
-    shoulda-matchers (1.3.0)
-      activesupport (>= 3.0.0)
     simplecov (0.6.4)
       multi_json (~> 1.0)
       simplecov-html (~> 0.5.3)
@@ -268,7 +277,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails
   sequel
-  shoulda-matchers
+  shoulda-matchers!
   simplecov
   simplecov-rcov
   therubyracer

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -86,6 +86,7 @@ class MeasureComponent < Sequel::Model
                        primary_key: :measure_sid
 
   delegate :description, :abbreviation, to: :duty_expression, prefix: true
+  delegate :abbreviation, to: :monetary_unit, prefix: true, allow_nil: true
 end
 
 

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -164,6 +164,8 @@ class MeasureCondition < Sequel::Model
     end
   end)
 
+  delegate :abbreviation, to: :monetary_unit, prefix: true, allow_nil: true
+
   def before_create
     self.measure_condition_sid ||= self.class.next_national_sid
 
@@ -186,6 +188,7 @@ class MeasureCondition < Sequel::Model
         sequence_number: component_sequence_number,
         duty_amount: condition_duty_amount,
         monetary_unit: condition_monetary_unit_code,
+        monetary_unit_abbreviation: monetary_unit_abbreviation,
         measurement_unit: measurement_unit.try(:description),
         measurement_unit_qualifier: measurement_unit_qualifier.try(:description)
       }

--- a/app/models/monetary_unit.rb
+++ b/app/models/monetary_unit.rb
@@ -6,7 +6,7 @@ class MonetaryUnit < Sequel::Model
   one_to_one :monetary_unit_description, key: :monetary_unit_code,
                                          primary_key: :monetary_unit_code
 
-  delegate :description, to: :monetary_unit_description
+  delegate :description, :abbreviation, to: :monetary_unit_description
 
   def to_s
     monetary_unit_code

--- a/app/views/api/v1/measures/_measure.json.rabl
+++ b/app/views/api/v1/measures/_measure.json.rabl
@@ -32,6 +32,9 @@ child(measure_components: :measure_components) do
   node(:monetary_unit) { |component|
     component.monetary_unit_code
   }
+  node(:monetary_unit_abbreviation) { |component|
+    component.monetary_unit_abbreviation
+  }
   node(:measurement_unit) { |component|
     component.measurement_unit.try(:description)
   }
@@ -49,6 +52,9 @@ child(measure_conditions: :measure_conditions) do
 
     node(:monetary_unit) { |component|
       component.monetary_unit_code
+    }
+    node(:monetary_unit_abbreviation) { |component|
+      component.monetary_unit_abbreviation
     }
     node(:measurement_unit) { |component|
       component.measurement_unit.try(:description)

--- a/db/migrate/20121022135253_add_currency_abbreviation.rb
+++ b/db/migrate/20121022135253_add_currency_abbreviation.rb
@@ -1,0 +1,15 @@
+Sequel.migration do
+  up do
+    alter_table :monetary_unit_descriptions do
+      add_column :abbreviation, String, size: 30
+    end
+
+    MonetaryUnitDescription.where(monetary_unit_code: 'EUC').update(abbreviation: 'EUR (EUC)')
+  end
+
+  down do
+    alter_table :monetary_unit_descriptions do
+      drop_column :abbreviation
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1222,6 +1222,7 @@ Sequel.migration do
       column :description, "text"
       column :created_at, "datetime"
       column :updated_at, "datetime"
+      column :abbreviation, "varchar(30)"
 
       index [:language_id], :name=>:index_monetary_unit_descriptions_on_language_id
       index [:monetary_unit_code], :name=>:primary_key, :unique=>true
@@ -1535,6 +1536,7 @@ Sequel.migration do
     self[:schema_migrations].insert(:filename => "20121009120028_add_tariff_measure_number.rb")
     self[:schema_migrations].insert(:filename => "20121015072148_drop_tamf_le_tsmp.rb")
     self[:schema_migrations].insert(:filename => "20121019094932_convert_san_marino_to_italy_on_national_measures.rb")
+    self[:schema_migrations].insert(:filename => "20121022135253_add_currency_abbreviation.rb")
 
     create_table(:search_references) do
       primary_key :id, :type=>"int(11)"

--- a/spec/models/measure_component_spec.rb
+++ b/spec/models/measure_component_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe MeasureComponent do
+  describe 'delegations' do
+    it { should delegate_method(:duty_expression_description).to(:duty_expression).as(:description) }
+    it { should delegate_method(:duty_expression_abbreviation).to(:duty_expression).as(:abbreviation) }
+    it { should delegate_method(:monetary_unit_abbreviation).to(:monetary_unit).as(:abbreviation) }
+  end
+end

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe MeasureComponent do
+  describe 'delegations' do
+    it { should delegate_method(:monetary_unit_abbreviation).to(:monetary_unit).as(:abbreviation) }
+  end
+end

--- a/spec/models/monetary_unit_spec.rb
+++ b/spec/models/monetary_unit_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe MonetaryUnit do
+  describe 'delegations' do
+    it { should delegate_method(:description).to(:monetary_unit_description) }
+    it { should delegate_method(:abbreviation).to(:monetary_unit_description) }
+  end
+end


### PR DESCRIPTION
For some monetary units we need to display their alternative names, like EUC = EUR (EUC).

It is more like an alias than an abbreviation, but trying to keep it consistent with DutyExpressionDescription. 

This solves https://www.pivotaltracker.com/story/show/37711521 on Pivotal.
