### PR TITLE
Extend Heading#declarable query to support grouping headings.

### DIFF
--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -74,7 +74,9 @@ class Heading < GoodsNomenclature
 
   def declarable
     actual(GoodsNomenclature).where("goods_nomenclature_item_id LIKE ?", "#{short_code}______")
-                             .count == 1
+                             .where("goods_nomenclature_item_id >= ?", goods_nomenclature_item_id)
+                             .where("producline_suffix > ?", producline_suffix)
+                             .count == 0
   end
   alias :declarable? :declarable
 

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -83,18 +83,36 @@ describe Heading do
   end
 
   describe '#declarable' do
-    let!(:declarable_heading)     { create :heading, goods_nomenclature_item_id: "0101000000"}
-    let!(:non_declarable_heading) { create :heading, goods_nomenclature_item_id: "0102000000" }
-    let!(:commodity)              { create :commodity, goods_nomenclature_item_id: "0102000010",
-                                                       validity_start_date: non_declarable_heading.validity_start_date,
-                                                       validity_end_date: non_declarable_heading.validity_end_date }
+    context 'different commodity codes' do
+      let!(:declarable_heading)     { create :heading, goods_nomenclature_item_id: "0101000000"}
+      let!(:non_declarable_heading) { create :heading, goods_nomenclature_item_id: "0102000000", producline_suffix: "10" }
+      let!(:commodity)              { create :commodity, goods_nomenclature_item_id: "0102000010",
+                                                         producline_suffix: "80",
+                                                         validity_start_date: non_declarable_heading.validity_start_date,
+                                                         validity_end_date: non_declarable_heading.validity_end_date }
 
-    it 'returns true if there are no commodities under this heading that are valid during headings validity period' do
-      declarable_heading.declarable.should be_true
+      it 'returns true if there are no commodities under this heading that are valid during headings validity period' do
+        declarable_heading.declarable.should be_true
+      end
+
+      it 'returns false if there are commodities under the heading that are valid during headings validity period' do
+        non_declarable_heading.declarable.should be_false
+      end
     end
 
-    it 'returns false if there are commodities under the heading that are valid during headings validity period' do
-      non_declarable_heading.declarable.should be_false
+    context 'same commodity codes' do
+      let!(:heading1) { create :heading, goods_nomenclature_item_id: "0101000000",
+                                         producline_suffix: "10"}
+      let!(:heading2) { create :heading, goods_nomenclature_item_id: "0101000000",
+                                         producline_suffix: "80" }
+
+      it 'returns true if there are no commodities under this heading that are valid during headings validity period' do
+        heading1.declarable.should be_false
+      end
+
+      it 'returns false if there are commodities under the heading that are valid during headings validity period' do
+        heading2.declarable.should be_true
+      end
     end
   end
 end


### PR DESCRIPTION
Example: https://www.gov.uk/trade-tariff/headings/6309 should be
declarable and show measure list.
