### PR TITLE
Fix GoodsNomenclature -> Chapter,Heading,Commodity STI working.

### DIFF
--- a/app/models/goods_nomenclature.rb
+++ b/app/models/goods_nomenclature.rb
@@ -4,6 +4,20 @@ class GoodsNomenclature < Sequel::Model
   plugin :time_machine, period_start_column: :goods_nomenclatures__validity_start_date,
                         period_end_column:   :goods_nomenclatures__validity_end_date
 
+  plugin :sti, class_determinator: ->(record) {
+    gono_id = record[:goods_nomenclature_item_id].to_s
+
+    if gono_id.ends_with?('00000000')
+      'Chapter'
+    elsif gono_id.ends_with?('000000') && gono_id.slice(2,2) != '00'
+      'Heading'
+    elsif !gono_id.ends_with?('000000')
+      'Commodity'
+    else
+      'GoodsNomenclature'
+    end
+  }
+
   set_dataset order(:goods_nomenclatures__goods_nomenclature_item_id.asc)
 
   set_primary_key :goods_nomenclature_sid

--- a/lib/sequel/plugins/sti.rb
+++ b/lib/sequel/plugins/sti.rb
@@ -1,0 +1,33 @@
+# Based on: https://github.com/jeremyevans/sequel/blob/master/lib/sequel/plugins/single_table_inheritance.rb
+
+module Sequel
+  module Plugins
+    module Sti
+      def self.configure(model, opts={})
+        model.instance_eval do
+          @class_determinator = opts[:class_determinator]
+          dataset.row_proc = lambda{|r| model.sti_load(r) }
+        end
+      end
+
+      module ClassMethods
+        attr_reader :class_determinator
+
+        def inherited(subclass)
+          super
+
+          cd = class_determinator
+          rp = dataset.row_proc
+          subclass.instance_eval do
+            @class_determinator = cd
+            dataset.row_proc = lambda{|r| model.sti_load(r) }
+          end
+        end
+
+        def sti_load(r)
+          constantize(class_determinator.call(r)).call(r)
+        end
+      end
+    end
+  end
+end

--- a/lib/sequel/plugins/tariff_validation_helpers.rb
+++ b/lib/sequel/plugins/tariff_validation_helpers.rb
@@ -22,6 +22,12 @@ module Sequel
               if o.validity_end_date.present? && associated_record.validity_end_date.present?
                  o.errors.add(a, error_message) if associated_record.validity_end_date < o.validity_end_date
               end
+              if o.validity_start_date.present? && associated_record.validity_end_date.present?
+                 o.errors.add(a, error_message) if associated_record.validity_end_date < o.validity_start_date
+              end
+              if o.validity_end_date.present? && associated_record.validity_start_date.present?
+                 o.errors.add(a, error_message) if associated_record.validity_start_date > o.validity_end_date
+              end
             end
           end
         end
@@ -85,7 +91,12 @@ module Sequel
 
           validates_each(*atts) do |object, association, value|
             if object.send(association).present?
-              object.errors.add(association, opts[:message] % [association]) unless object.send(opts[:ensure])
+              if opts[:ensure].present?
+                object.errors.add(association, opts[:message] % [association]) unless object.send(opts[:ensure])
+              else
+                associated_records = [object.send(association)].flatten
+                object.errors.add(association, opts[:message] % [association]) unless associated_records.all?(&:valid?)
+              end
             end
           end
         end

--- a/spec/factories/chief_record_factory.rb
+++ b/spec/factories/chief_record_factory.rb
@@ -53,6 +53,7 @@ FactoryGirl.define do
     trait :with_goods_nomenclature do
       before(:create) { |mfcm|
         FactoryGirl.create :goods_nomenclature, :fifteen_years, :declarable,
+                           :with_indent,
                            goods_nomenclature_item_id: mfcm.cmdty_code
       }
     end

--- a/spec/factories/goods_nomenclature_factory.rb
+++ b/spec/factories/goods_nomenclature_factory.rb
@@ -34,6 +34,8 @@ FactoryGirl.define do
     trait :with_indent do
       after(:create) { |gono, evaluator|
         FactoryGirl.create(:goods_nomenclature_indent, goods_nomenclature_sid: gono.goods_nomenclature_sid,
+                                                       validity_start_date: gono.validity_start_date,
+                                                       validity_end_date: gono.validity_end_date,
                                                        number_indents: evaluator.indents)
       }
     end

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -12,6 +12,10 @@ FactoryGirl.define do
     validity_start_date { Date.today.ago(3.years) }
     validity_end_date   { nil }
 
+    trait :national do
+      national { true }
+    end
+
     trait :with_goods_nomenclature do
       after(:create) { |measure, evaluator|
         FactoryGirl.create(:goods_nomenclature, goods_nomenclature_sid: measure.goods_nomenclature_sid,


### PR DESCRIPTION
Ruby inheritance with Sequel models work in a weird way that is internal and unlikely to change. The provided STI plugin is not good enough, because it expects record type to be specified in the column and not identified by pattern. The problem:

Before:

``` ruby
[1] pry(main)> GoodsNomenclature.first
=> #<GoodsNomenclature @values={:goods_nomenclature_sid=>27623, :goods_nomenclature_item_id=>"0100000000", :producline_suffix=>"80", :validity_start_date=>1971-12-31 00:00:00 +0300, :validity_end_date=>nil, :statistical_indicator=>0, :created_at=>nil, :updated_at=>nil}>
[2] pry(main)> Commodity.first
=> #<Commodity @values={:goods_nomenclature_sid=>72760, :goods_nomenclature_item_id=>"0101100000", :producline_suffix=>"80", :validity_start_date=>2002-01-01 00:00:00 +0200, :validity_end_date=>2011-12-31 00:00:00 +0200, :statistical_indicator=>0, :created_at=>nil, :updated_at=>nil}>
[3] pry(main)> GoodsNomenclature.first
=> #<Commodity @values={:goods_nomenclature_sid=>27623, :goods_nomenclature_item_id=>"0100000000", :producline_suffix=>"80", :validity_start_date=>1971-12-31 00:00:00 +0300, :validity_end_date=>nil, :statistical_indicator=>0, :created_at=>nil, :updated_at=>nil}>
[4] pry(main)> Heading.first
=> #<Heading @values={:goods_nomenclature_sid=>27624, :goods_nomenclature_item_id=>"0101000000", :producline_suffix=>"80", :validity_start_date=>1972-01-01 00:00:00 +0300, :validity_end_date=>nil, :statistical_indicator=>0, :created_at=>nil, :updated_at=>nil}>
[5] pry(main)> GoodsNomenclature.first
=> #<Heading @values={:goods_nomenclature_sid=>27623, :goods_nomenclature_item_id=>"0100000000", :producline_suffix=>"80", :validity_start_date=>1971-12-31 00:00:00 +0300, :validity_end_date=>nil, :statistical_indicator=>0, :created_at=>nil, :updated_at=>nil}>
```

After:

``` ruby
[5] pry(main)> GoodsNomenclature.first
=> #<Chapter @values={:goods_nomenclature_sid=>27623, :goods_nomenclature_item_id=>"0100000000", :producline_suffix=>"80", :validity_start_date=>1971-12-31 00:00:00 +0300, :validity_end_date=>nil, :statistical_indicator=>0, :created_at=>nil, :updated_at=>nil}>
[6] pry(main)> Commodity.first                                                                                                  
=> #<Commodity @values={:goods_nomenclature_sid=>72760, :goods_nomenclature_item_id=>"0101100000", :producline_suffix=>"80", :validity_start_date=>2002-01-01 00:00:00 +0200, :validity_end_date=>2011-12-31 00:00:00 +0200, :statistical_indicator=>0, :created_at=>nil, :updated_at=>nil}>
[7] pry(main)> GoodsNomenclature.first                                                                                          
=> #<Chapter @values={:goods_nomenclature_sid=>27623, :goods_nomenclature_item_id=>"0100000000", :producline_suffix=>"80", :validity_start_date=>1971-12-31 00:00:00 +0300, :validity_end_date=>nil, :statistical_indicator=>0, :created_at=>nil, :updated_at=>nil}>
[8] pry(main)> Heading.first
=> #<Heading @values={:goods_nomenclature_sid=>27624, :goods_nomenclature_item_id=>"0101000000", :producline_suffix=>"80", :validity_start_date=>1972-01-01 00:00:00 +0300, :validity_end_date=>nil, :statistical_indicator=>0, :created_at=>nil, :updated_at=>nil}>
[9] pry(main)> GoodsNomenclature.first                                                                                          
=> #<Chapter @values={:goods_nomenclature_sid=>27623, :goods_nomenclature_item_id=>"0100000000", :producline_suffix=>"80", :validity_start_date=>1971-12-31 00:00:00 +0300, :validity_end_date=>nil, :statistical_indicator=>0, :created_at=>nil, :updated_at=>nil}>
```
