### PR TITLE
Move import handlers under Commodity as we have proper casting now.

### DIFF
--- a/lib/chief_transformer/candidate_measure/collection.rb
+++ b/lib/chief_transformer/candidate_measure/collection.rb
@@ -14,7 +14,8 @@ class ChiefTransformer
       def uniq
         @measures = @measures.uniq {|m|
           [m.measure_type, m.geographical_area, m.goods_nomenclature_item_id,
-           m.additional_code_type, m.additional_code, m.validity_start_date].join
+           m.additional_code_type, m.additional_code, m.validity_start_date,
+           m.validity_end_date].join
         }
       end
 

--- a/lib/tariff_importer/importers/taric_importer.rb
+++ b/lib/tariff_importer/importers/taric_importer.rb
@@ -25,9 +25,6 @@ class TaricImporter
   cattr_accessor :transaction_node
   self.transaction_node = 'env:transaction'
 
-  cattr_accessor :ignored_strategies
-  self.ignored_strategies = %w()
-
   attr_reader :path
 
   def initialize(path)
@@ -48,10 +45,7 @@ class TaricImporter
                 begin
                   node_name = mxml.xpath("record/update.type/following-sibling::*").first.node_name
                   record_type = strategy_for(node_name)
-
-                  unless self.ignored_strategies.include?(record_type)
-                    record_type.constantize.new(mxml).process!
-                  end
+                  record_type.constantize.new(mxml).process!
                 rescue NameError => exception
                   ActiveSupport::Notifications.instrument("taric_failed.tariff_importer", exception: exception,
                                                                                           xml: mxml)

--- a/lib/tariff_importer/importers/taric_importer/strategies/strategies.rb
+++ b/lib/tariff_importer/importers/taric_importer/strategies/strategies.rb
@@ -160,6 +160,12 @@ class TaricImporter
         end
       }
     end
+    class Commodity < GoodsNomenclature
+    end
+    class Heading < GoodsNomenclature
+    end
+    class Chapter < GoodsNomenclature
+    end
     class GoodsNomenclatureIndent < BaseStrategy
     end
     class GoodsNomenclatureDescriptionPeriod < BaseStrategy

--- a/spec/unit/chief_transformer/candidate_measure_collection_spec.rb
+++ b/spec/unit/chief_transformer/candidate_measure_collection_spec.rb
@@ -60,4 +60,95 @@ describe ChiefTransformer::CandidateMeasure::Collection do
       end
     end
   end
+
+  describe "#uniq" do
+    context 'different validity end dates' do
+      let!(:mfcm) { create :mfcm, :unprocessed,
+                                  cmdty_code: '8452300000',
+                                  msrgp_code: 'VT',
+                                  msr_type: 'S',
+                                  tty_code: 'B00',
+                                  fe_tsmp: DateTime.new(2012,1,1) }
+
+      let!(:tame1) { create :tame, :unprocessed,
+                                   fe_tsmp: DateTime.new(2007,10,1),
+                                   le_tsmp: DateTime.new(2008,12,1),
+                                   msrgp_code: 'VT',
+                                   msr_type: 'S',
+                                   tty_code: 'B00' }
+
+      let!(:tame2) { create :tame, :unprocessed,
+                                   fe_tsmp: DateTime.new(2008,12,1),
+                                   le_tsmp: DateTime.new(2010,1,1),
+                                   msrgp_code: 'VT',
+                                   msr_type: 'S',
+                                   tty_code: 'B00' }
+
+      let!(:tame3) { create :tame, :unprocessed,
+                                   fe_tsmp: DateTime.new(2010,1,1),
+                                   le_tsmp: DateTime.new(2011,1,4),
+                                   msrgp_code: 'VT',
+                                   msr_type: 'S',
+                                   tty_code: 'B00' }
+
+      let!(:tame4) { create :tame, :unprocessed,
+                                   fe_tsmp: DateTime.new(2011,1,4),
+                                   msrgp_code: 'VT',
+                                   msr_type: 'S',
+                                   tty_code: 'B00' }
+
+      let(:candidate_measures) {
+        ChiefTransformer::CandidateMeasure::Collection.new(mfcm.tames.map{|tame|
+          ChiefTransformer::CandidateMeasure.new(mfcm: mfcm, tame: tame)
+        })
+      }
+
+      it 'validity end dates differentiate measures' do
+        candidate_measures.uniq.size.should eq mfcm.tames.size
+      end
+    end
+
+    context 'same validity end dates' do
+      let!(:mfcm) { create :mfcm, :unprocessed,
+                                  cmdty_code: '8452300000',
+                                  msrgp_code: 'VT',
+                                  msr_type: 'S',
+                                  tty_code: 'B00',
+                                  fe_tsmp: DateTime.new(2012,1,1) }
+
+      let!(:tame1) { create :tame, :unprocessed,
+                                   fe_tsmp: DateTime.new(2007,10,1),
+                                   msrgp_code: 'VT',
+                                   msr_type: 'S',
+                                   tty_code: 'B00' }
+
+      let!(:tame2) { create :tame, :unprocessed,
+                                   fe_tsmp: DateTime.new(2008,12,1),
+                                   msrgp_code: 'VT',
+                                   msr_type: 'S',
+                                   tty_code: 'B00' }
+
+      let!(:tame3) { create :tame, :unprocessed,
+                                   fe_tsmp: DateTime.new(2010,1,1),
+                                   msrgp_code: 'VT',
+                                   msr_type: 'S',
+                                   tty_code: 'B00' }
+
+      let!(:tame4) { create :tame, :unprocessed,
+                                   fe_tsmp: DateTime.new(2011,1,4),
+                                   msrgp_code: 'VT',
+                                   msr_type: 'S',
+                                   tty_code: 'B00' }
+
+      let(:candidate_measures) {
+        ChiefTransformer::CandidateMeasure::Collection.new(mfcm.tames.map{|tame|
+          ChiefTransformer::CandidateMeasure.new(mfcm: mfcm, tame: tame)
+        })
+      }
+
+      it 'removes duplicate measures' do
+        candidate_measures.uniq.size.should eq 1
+      end
+    end
+  end
 end


### PR DESCRIPTION
We are missing fair amount of national measures on various commodities. This fixes initial CHIEF seed loading: candidate measure's validity end date should have been part of the key. And it used to be, but there was an issue raised about duplicate national measures. Unfortunately, I couldn't find the issue in question, so I can't double check that now. I added a test case so validity end date won't be removed any more. If there will be duplicate measures somewhere we will need to sort that in different way.

And again I'm sorry but the only way to fix this is to reload the database. I uploaded a snapshot snapshot_for-12-12-2012.sql.bz2 do Dropbox. I think we a viable solution based on [Event Sourcing](http://martinfowler.com/eaaDev/EventSourcing.html) to prevent these reloads (at least for the daily updates), that hopefully will be implemented.

I also been digging our previous issues and fixes and come up with a list of things to check for:

```
1. 4017 should be declarable heading
2. 0810301000 at 5th of June should have measure for Montenegro, Albania
3. 0803109000 at 5th of June should have measure for Eastern and Southern Africa States
4. 7616999091 at 5th of June should not have measure "Autonomous suspension under end use"
5. 3901109090 at 5th of June should have BERR Import Licensing Firearms and Ammunition national measure for Iran.
6. 9619005100 at 5th of June should not have "VAT reduced rate 5%" measure
7. 9619004900 at 5th of June should not have VAT zero rate.
8. 0810100000 at 2nd of Oct should have "HMI Conformity Certificate" measure.
9. 4401310000 at 12th of Dec should have VAT Standard rate
10. 8401100000 at 12th of Dec should have  VAT Standard rate
11. 4601211000 at 12th of Dec should have  VAT Standard rate
12. 8401400000 at 12th of Dec should have VAT Standard rate
13. 8423811000 at 12h of Dec should have  VAT Standard rate
14. 8516101100 at 12th of Dec should have  VAT Standard rate
15. 8418211000 at 12th of Dec should have  VAT Standard rate
16. 8452101100 at 12th of Dec should have  VAT Standard rate
17. 8452300000 at 12th of Dec should have VAT Standard rate
```

Do these qualify as smokey tests? The problem I see is that both Taric and CHIEF may remove any measure at any time, so test will result in error even though nothing bad may have happened.

This list could of course serve as way to check if release was successful.
