### PR TITLE
Remove usage of Plek.current.environment

### DIFF
--- a/config/initializers/mailer_env.rb
+++ b/config/initializers/mailer_env.rb
@@ -1,0 +1,1 @@
+MAILER_ENV = "development"

--- a/config/initializers/mailer_environment.rb
+++ b/config/initializers/mailer_environment.rb
@@ -1,0 +1,5 @@
+module MailerEnvironment
+  def environment_indicator
+    "(#{MAILER_ENV})"
+  end
+end

--- a/lib/chief_transformer/mailer.rb
+++ b/lib/chief_transformer/mailer.rb
@@ -1,10 +1,12 @@
 class ChiefTransformer
   class Mailer < ActionMailer::Base
+    include MailerEnvironment
+
     default from: "DO NOT REPLY <trade-tariff-alerts@digital.cabinet-office.gov.uk>",
             to: TradeTariffBackend.admin_email
 
     def successful_transformation_notice
-      mail subject: "[info] Successful CHIEF transformation on #{Plek.current.environment}"
+      mail subject: "[info] Successful CHIEF transformation #{environment_indicator}"
     end
 
     def failed_transformation_notice(operation, exception, model, errors)
@@ -13,7 +15,7 @@ class ChiefTransformer
       @model = model
       @errors = errors
 
-      mail subject: "[error] Failed CHIEF transformation on #{Plek.current.environment}"
+      mail subject: "[error] Failed CHIEF transformation #{environment_indicator}"
     end
   end
 end

--- a/lib/tariff_synchronizer/mailer.rb
+++ b/lib/tariff_synchronizer/mailer.rb
@@ -1,5 +1,7 @@
 module TariffSynchronizer
   class Mailer < ActionMailer::Base
+    include MailerEnvironment
+
     default from: "DO NOT REPLY <trade-tariff-alerts@digital.cabinet-office.gov.uk>",
             to: TradeTariffBackend.admin_email
 
@@ -47,11 +49,6 @@ module TariffSynchronizer
       @count = count
 
       mail subject: "[info] Tariff updates applied #{environment_indicator}"
-    end
-
-    private
-    def environment_indicator
-      "on #{Plek.current.environment}"
     end
   end
 end


### PR DESCRIPTION
It has been removed in v1.0.0 and we need a different mechanism.
Different initializers will be provided at deployment time to set
the constant to a particular value.

See alphagov/alphagov-deployment#74
