### PR TITLE
Use snowball for referenced match search.

### DIFF
--- a/app/models/search_reference.rb
+++ b/app/models/search_reference.rb
@@ -10,10 +10,9 @@ class SearchReference < Sequel::Model
     document_type 'search_reference'
 
     mapping do
-      indexes :title,        analyzer: :simple
+      indexes :title,        analyzer: :snowball, type: :string
     end
   end
-
 
   def referenced_entity
     @referenced_entity ||= case reference

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -124,8 +124,10 @@ class SearchService
 
     def reference_search(query_string)
       @reference_results ||= Tire.search('search_references', { query: {
-                                               term: {
-                                                 title: query_string
+                                               query_string: {
+                                                 fields: ['title'],
+                                                 analyzer: 'snowball',
+                                                 query: query_string
                                                }
                                              },
                                              size: INDEX_SIZE_MAX

--- a/spec/vcr/search_search_fuzzy.yml
+++ b/spec/vcr/search_search_fuzzy.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:9200/sections/_search?payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Bmissing%5D%5Bfield%5D=validity_end_date&payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=<%= Date.today %>&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_end_date%5D%5Bgte%5D=<%= Date.today %>&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=<%= Date.today %>&payload%5Bquery%5D%5Bquery_string%5D%5Bfields%5D%5B0%5D=description&payload%5Bquery%5D%5Bquery_string%5D%5Bquery%5D=horse&payload%5Bquery%5D%5Bquery_string%5D%5Bquery_string%5D%5Bfields%5D%5B0%5D=title&payload%5Bsize%5D=1000000
+    uri: http://localhost:9200/sections/_search?payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Bmissing%5D%5Bfield%5D=validity_end_date&payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=2013-01-10&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_end_date%5D%5Bgte%5D=2013-01-10&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=2013-01-10&payload%5Bquery%5D%5Bquery_string%5D%5Bfields%5D%5B0%5D=description&payload%5Bquery%5D%5Bquery_string%5D%5Bquery%5D=horse&payload%5Bquery%5D%5Bquery_string%5D%5Bquery_string%5D%5Bfields%5D%5B0%5D=title&payload%5Bsize%5D=1000000
     body:
       encoding: US-ASCII
-      string: ! '{"query":{"query_string":{"query":"horse","fields":["description"],"query_string":{"fields":["title"]}}},"filter":{"or":[{"range":{"validity_start_date":{"lte":"<%= Date.today %>"},"validity_end_date":{"gte":"<%= Date.today %>"}}},{"and":[{"range":{"validity_start_date":{"lte":"<%= Date.today %>"}}},{"missing":{"field":"validity_end_date"}}]}]},"size":1000000}'
+      string: ! '{"query":{"query_string":{"query":"horse","fields":["description"],"query_string":{"fields":["title"]}}},"filter":{"or":[{"range":{"validity_start_date":{"lte":"2013-01-10"},"validity_end_date":{"gte":"2013-01-10"}}},{"and":[{"range":{"validity_start_date":{"lte":"2013-01-10"}}},{"missing":{"field":"validity_end_date"}}]}]},"size":1000000}'
     headers:
       Accept:
       - ! '*/*; q=0.5, application/xml'
@@ -23,18 +23,18 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
-      - '124'
+      - '122'
     body:
       encoding: US-ASCII
-      string: ! '{"took":132,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'
-    http_version:
-  recorded_at: Tue, 09 Oct 2012 07:59:51 GMT
+      string: ! '{"took":2,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 10:39:29 GMT
 - request:
     method: get
-    uri: http://localhost:9200/chapters/_search?payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Bmissing%5D%5Bfield%5D=validity_end_date&payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=<%= Date.today %>&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_end_date%5D%5Bgte%5D=<%= Date.today %>&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=<%= Date.today %>&payload%5Bquery%5D%5Bquery_string%5D%5Bfields%5D%5B0%5D=description&payload%5Bquery%5D%5Bquery_string%5D%5Bquery%5D=horse&payload%5Bsize%5D=1000000
+    uri: http://localhost:9200/chapters/_search?payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Bmissing%5D%5Bfield%5D=validity_end_date&payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=2013-01-10&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_end_date%5D%5Bgte%5D=2013-01-10&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=2013-01-10&payload%5Bquery%5D%5Bquery_string%5D%5Bfields%5D%5B0%5D=description&payload%5Bquery%5D%5Bquery_string%5D%5Bquery%5D=horse&payload%5Bsize%5D=1000000
     body:
       encoding: US-ASCII
-      string: ! '{"query":{"query_string":{"query":"horse","fields":["description"]}},"filter":{"or":[{"range":{"validity_start_date":{"lte":"<%= Date.today %>"},"validity_end_date":{"gte":"<%= Date.today %>"}}},{"and":[{"range":{"validity_start_date":{"lte":"<%= Date.today %>"}}},{"missing":{"field":"validity_end_date"}}]}]},"size":1000000}'
+      string: ! '{"query":{"query_string":{"query":"horse","fields":["description"]}},"filter":{"or":[{"range":{"validity_start_date":{"lte":"2013-01-10"},"validity_end_date":{"gte":"2013-01-10"}}},{"and":[{"range":{"validity_start_date":{"lte":"2013-01-10"}}},{"missing":{"field":"validity_end_date"}}]}]},"size":1000000}'
     headers:
       Accept:
       - ! '*/*; q=0.5, application/xml'
@@ -52,18 +52,18 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
-      - '123'
+      - '122'
     body:
       encoding: US-ASCII
-      string: ! '{"took":88,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'
-    http_version:
-  recorded_at: Tue, 09 Oct 2012 07:59:51 GMT
+      string: ! '{"took":2,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 10:39:29 GMT
 - request:
     method: get
-    uri: http://localhost:9200/headings/_search?payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Bmissing%5D%5Bfield%5D=validity_end_date&payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=<%= Date.today %>&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_end_date%5D%5Bgte%5D=<%= Date.today %>&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=<%= Date.today %>&payload%5Bquery%5D%5Bquery_string%5D%5Bfields%5D%5B0%5D=description&payload%5Bquery%5D%5Bquery_string%5D%5Bquery%5D=horse&payload%5Bsize%5D=1000000
+    uri: http://localhost:9200/headings/_search?payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Bmissing%5D%5Bfield%5D=validity_end_date&payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=2013-01-10&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_end_date%5D%5Bgte%5D=2013-01-10&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=2013-01-10&payload%5Bquery%5D%5Bquery_string%5D%5Bfields%5D%5B0%5D=description&payload%5Bquery%5D%5Bquery_string%5D%5Bquery%5D=horse&payload%5Bsize%5D=1000000
     body:
       encoding: US-ASCII
-      string: ! '{"query":{"query_string":{"query":"horse","fields":["description"]}},"filter":{"or":[{"range":{"validity_start_date":{"lte":"<%= Date.today %>"},"validity_end_date":{"gte":"<%= Date.today %>"}}},{"and":[{"range":{"validity_start_date":{"lte":"<%= Date.today %>"}}},{"missing":{"field":"validity_end_date"}}]}]},"size":1000000}'
+      string: ! '{"query":{"query_string":{"query":"horse","fields":["description"]}},"filter":{"or":[{"range":{"validity_start_date":{"lte":"2013-01-10"},"validity_end_date":{"gte":"2013-01-10"}}},{"and":[{"range":{"validity_start_date":{"lte":"2013-01-10"}}},{"missing":{"field":"validity_end_date"}}]}]},"size":1000000}'
     headers:
       Accept:
       - ! '*/*; q=0.5, application/xml'
@@ -81,10 +81,10 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
-      - '2132'
+      - '2131'
     body:
       encoding: US-ASCII
-      string: ! '{"took":116,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":3,"max_score":2.5602632,"hits":[{"_index":"headings","_type":"heading","_id":"27624","_score":2.5602632,
+      string: ! '{"took":71,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":3,"max_score":2.5602632,"hits":[{"_index":"headings","_type":"heading","_id":"27624","_score":2.5602632,
         "_source" : {"id":27624,"goods_nomenclature_item_id":"0101000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Live
         horses, asses, mules and hinnies","number_indents":0,"section":{"numeral":"I","title":"Live
         animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":27623,"goods_nomenclature_item_id":"0100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"live
@@ -98,14 +98,14 @@ http_interactions:
         fresh, chilled or frozen","number_indents":0,"section":{"numeral":"I","title":"Live
         animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":27809,"goods_nomenclature_item_id":"0200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"meat
         and edible meat offal"}}}]}}'
-    http_version:
-  recorded_at: Tue, 09 Oct 2012 07:59:51 GMT
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 10:39:29 GMT
 - request:
     method: get
-    uri: http://localhost:9200/commodities/_search?payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Bmissing%5D%5Bfield%5D=validity_end_date&payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=<%= Date.today %>&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_end_date%5D%5Bgte%5D=<%= Date.today %>&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=<%= Date.today %>&payload%5Bquery%5D%5Bquery_string%5D%5Bfields%5D%5B0%5D=description&payload%5Bquery%5D%5Bquery_string%5D%5Bquery%5D=horse&payload%5Bsize%5D=1000000
+    uri: http://localhost:9200/commodities/_search?payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Bmissing%5D%5Bfield%5D=validity_end_date&payload%5Bfilter%5D%5Bor%5D%5Band%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=2013-01-10&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_end_date%5D%5Bgte%5D=2013-01-10&payload%5Bfilter%5D%5Bor%5D%5Brange%5D%5Bvalidity_start_date%5D%5Blte%5D=2013-01-10&payload%5Bquery%5D%5Bquery_string%5D%5Bfields%5D%5B0%5D=description&payload%5Bquery%5D%5Bquery_string%5D%5Bquery%5D=horse&payload%5Bsize%5D=1000000
     body:
       encoding: US-ASCII
-      string: ! '{"query":{"query_string":{"query":"horse","fields":["description"]}},"filter":{"or":[{"range":{"validity_start_date":{"lte":"<%= Date.today %>"},"validity_end_date":{"gte":"<%= Date.today %>"}}},{"and":[{"range":{"validity_start_date":{"lte":"<%= Date.today %>"}}},{"missing":{"field":"validity_end_date"}}]}]},"size":1000000}'
+      string: ! '{"query":{"query_string":{"query":"horse","fields":["description"]}},"filter":{"or":[{"range":{"validity_start_date":{"lte":"2013-01-10"},"validity_end_date":{"gte":"2013-01-10"}}},{"and":[{"range":{"validity_start_date":{"lte":"2013-01-10"}}},{"missing":{"field":"validity_end_date"}}]}]},"size":1000000}'
     headers:
       Accept:
       - ! '*/*; q=0.5, application/xml'
@@ -123,71 +123,76 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
-      - '16439'
+      - '16998'
     body:
       encoding: US-ASCII
-      string: ! '{"took":608,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":16,"max_score":8.203498,"hits":[{"_index":"commodities","_type":"commodity","_id":"93797","_score":8.203498,
+      string: ! '{"took":346,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":16,"max_score":8.196967,"hits":[{"_index":"commodities","_type":"commodity","_id":"93797","_score":8.196967,
         "_source" : {"id":93797,"goods_nomenclature_item_id":"0101210000","producline_suffix":"10","validity_start_date":"2012-01-01T00:00:00+02:00","validity_end_date":null,"description":"Horses","number_indents":1,"section":{"numeral":"I","title":"Live
         animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":27623,"goods_nomenclature_item_id":"0100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"live
-        animals"},"heading":{"goods_nomenclature_sid":27623,"goods_nomenclature_item_id":"0100000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"LIVE
-        ANIMALS","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"72799","_score":4.24573,
+        animals"},"heading":{"goods_nomenclature_sid":27624,"goods_nomenclature_item_id":"0101000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Live
+        horses, asses, mules and hinnies","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"72799","_score":4.242278,
         "_source" : {"id":72799,"goods_nomenclature_item_id":"0210991000","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+02:00","validity_end_date":null,"description":"Of
         horses, salted, in brine or dried","number_indents":4,"section":{"numeral":"I","title":"Live
         animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":27809,"goods_nomenclature_item_id":"0200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"meat
-        and edible meat offal"},"heading":{"goods_nomenclature_sid":27809,"goods_nomenclature_item_id":"0200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"MEAT
-        AND EDIBLE MEAT OFFAL","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"28100","_score":4.101749,
+        and edible meat offal"},"heading":{"goods_nomenclature_sid":28295,"goods_nomenclature_item_id":"0210000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Meat
+        and edible meat offal, salted, in brine, dried or smoked; edible flours and
+        meals of meat or meat offal","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"28100","_score":4.0984836,
         "_source" : {"id":28100,"goods_nomenclature_item_id":"0206809100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Of
         horses, asses, mules and hinnies","number_indents":3,"section":{"numeral":"I","title":"Live
         animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":27809,"goods_nomenclature_item_id":"0200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"meat
-        and edible meat offal"},"heading":{"goods_nomenclature_sid":27809,"goods_nomenclature_item_id":"0200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"MEAT
-        AND EDIBLE MEAT OFFAL","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"28105","_score":4.101749,
+        and edible meat offal"},"heading":{"goods_nomenclature_sid":28044,"goods_nomenclature_item_id":"0206000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Edible
+        offal of bovine animals, swine, sheep, goats, horses, asses, mules or hinnies,
+        fresh, chilled or frozen","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"28105","_score":4.0984836,
         "_source" : {"id":28105,"goods_nomenclature_item_id":"0206909100","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Of
         horses, asses, mules and hinnies","number_indents":3,"section":{"numeral":"I","title":"Live
         animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":27809,"goods_nomenclature_item_id":"0200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"meat
-        and edible meat offal"},"heading":{"goods_nomenclature_sid":27809,"goods_nomenclature_item_id":"0200000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"MEAT
-        AND EDIBLE MEAT OFFAL","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"95674","_score":3.8911417,
+        and edible meat offal"},"heading":{"goods_nomenclature_sid":28044,"goods_nomenclature_item_id":"0206000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Edible
+        offal of bovine animals, swine, sheep, goats, horses, asses, mules or hinnies,
+        fresh, chilled or frozen","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"95674","_score":3.8881948,
         "_source" : {"id":95674,"goods_nomenclature_item_id":"0302459010","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+02:00","validity_end_date":null,"description":"Horse
         mackerel (scad) (Caranx trachurus)","number_indents":4,"section":{"numeral":"I","title":"Live
         animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"fish
-        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"FISH
-        AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"94180","_score":3.7150137,
+        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28402,"goods_nomenclature_item_id":"0302000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Fish,
+        fresh or chilled, excluding fish fillets and other fish meat of heading|0304","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"94180","_score":3.7119932,
         "_source" : {"id":94180,"goods_nomenclature_item_id":"0303550000","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+02:00","validity_end_date":null,"description":"Jack
         and horse mackerel (Trachurus spp.)","number_indents":2,"section":{"numeral":"I","title":"Live
         animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"fish
-        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"FISH
-        AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"96208","_score":3.5890303,
-        "_source" : {"id":96208,"goods_nomenclature_item_id":"0303559010","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+02:00","validity_end_date":null,"description":"Horse
-        mackerel (scad) (Caranx trachurus)","number_indents":4,"section":{"numeral":"I","title":"Live
-        animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"fish
-        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"FISH
-        AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"93994","_score":3.5890303,
+        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28590,"goods_nomenclature_item_id":"0303000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Fish,
+        frozen, excluding fish fillets and other fish meat of heading|0304","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"93994","_score":3.586173,
         "_source" : {"id":93994,"goods_nomenclature_item_id":"0302451000","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+02:00","validity_end_date":null,"description":"Atlantic
         horse mackerel (Trachurus trachurus)","number_indents":3,"section":{"numeral":"I","title":"Live
         animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"fish
-        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"FISH
-        AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"94181","_score":3.4901829,
+        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28402,"goods_nomenclature_item_id":"0302000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Fish,
+        fresh or chilled, excluding fish fillets and other fish meat of heading|0304","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"96208","_score":3.586173,
+        "_source" : {"id":96208,"goods_nomenclature_item_id":"0303559010","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+02:00","validity_end_date":null,"description":"Horse
+        mackerel (scad) (Caranx trachurus)","number_indents":4,"section":{"numeral":"I","title":"Live
+        animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"fish
+        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28590,"goods_nomenclature_item_id":"0303000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Fish,
+        frozen, excluding fish fillets and other fish meat of heading|0304","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"94181","_score":3.4872358,
         "_source" : {"id":94181,"goods_nomenclature_item_id":"0303551000","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+02:00","validity_end_date":null,"description":"Atlantic
         horse mackerel (Trachurus trachurus)","number_indents":3,"section":{"numeral":"I","title":"Live
         animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"fish
-        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"FISH
-        AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"93993","_score":3.4901829,
+        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28590,"goods_nomenclature_item_id":"0303000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Fish,
+        frozen, excluding fish fillets and other fish meat of heading|0304","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"93993","_score":3.4872358,
         "_source" : {"id":93993,"goods_nomenclature_item_id":"0302450000","producline_suffix":"80","validity_start_date":"2012-01-01T00:00:00+02:00","validity_end_date":null,"description":"Jack
         and horse mackerel (Trachurus spp.)","number_indents":2,"section":{"numeral":"I","title":"Live
         animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"fish
-        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"FISH
-        AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"74274","_score":2.779387,
+        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28402,"goods_nomenclature_item_id":"0302000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Fish,
+        fresh or chilled, excluding fish fillets and other fish meat of heading|0304","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"74274","_score":2.777282,
         "_source" : {"id":74274,"goods_nomenclature_item_id":"2308004000","producline_suffix":"80","validity_start_date":"2002-01-01T00:00:00+02:00","validity_end_date":null,"description":"Acorns
         and horse-chestnuts; pomace or marc of fruit, other than grapes","number_indents":1,"section":{"numeral":"IV","title":"Prepared
         foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
         substitutes (chapters 16 to 24)","position":4},"chapter":{"goods_nomenclature_sid":35125,"goods_nomenclature_item_id":"2300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"residues
-        and waste from the food industries; prepared animal fodder"},"heading":{"goods_nomenclature_sid":35125,"goods_nomenclature_item_id":"2300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"RESIDUES
-        AND WASTE FROM THE FOOD INDUSTRIES; PREPARED ANIMAL FODDER","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"30763","_score":2.0508745,
+        and waste from the food industries; prepared animal fodder"},"heading":{"goods_nomenclature_sid":35179,"goods_nomenclature_item_id":"2308000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Vegetable
+        materials and vegetable waste, vegetable residues and by-products, whether
+        or not in the form of pellets, of a kind used in animal feeding, not elsewhere
+        specified or included","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"30763","_score":2.0492418,
         "_source" : {"id":30763,"goods_nomenclature_item_id":"0713500000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Broad
         beans (Vicia faba var. major) and horse beans (Vicia faba var. equina, Vicia
         faba var. minor)","number_indents":1,"section":{"numeral":"II","title":"Vegetable
         products (chapters 6 to 14)","position":2},"chapter":{"goods_nomenclature_sid":30240,"goods_nomenclature_item_id":"0700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"edible
-        vegetables and certain roots and tubers"},"heading":{"goods_nomenclature_sid":30240,"goods_nomenclature_item_id":"0700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"EDIBLE
-        VEGETABLES AND CERTAIN ROOTS AND TUBERS","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"91682","_score":1.4957926,
+        vegetables and certain roots and tubers"},"heading":{"goods_nomenclature_sid":30726,"goods_nomenclature_item_id":"0713000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Dried
+        leguminous vegetables, shelled, whether or not skinned or split","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"91682","_score":1.4945296,
         "_source" : {"id":91682,"goods_nomenclature_item_id":"4412321000","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+02:00","validity_end_date":null,"description":"Of
         alder, ash, beech, birch, cherry, chestnut, elm, hickory, hornbeam, horse
         chestnut, lime, maple, oak, plane tree, poplar, robinia, walnut or yellow
@@ -195,8 +200,8 @@ http_interactions:
         of wood; wood charcoal; cork and articles of cork; manufactures of straw,
         of esparto or of other plaiting materials; basket-ware and wickerwork (chapters
         44 to 46)","position":9},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"wood
-        and articles of wood; wood charcoal"},"heading":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"WOOD
-        AND ARTICLES OF WOOD; WOOD CHARCOAL","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"91687","_score":1.4957926,
+        and articles of wood; wood charcoal"},"heading":{"goods_nomenclature_sid":40191,"goods_nomenclature_item_id":"4412000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Plywood,
+        veneered panels and similar laminated wood","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"91687","_score":1.4945296,
         "_source" : {"id":91687,"goods_nomenclature_item_id":"4412994000","producline_suffix":"80","validity_start_date":"2010-01-01T00:00:00+02:00","validity_end_date":null,"description":"Of
         alder, ash, beech, birch, cherry, chestnut, elm, hickory, hornbeam, horse
         chestnut, lime, maple, oak, plane tree, poplar, robinia, walnut or yellow
@@ -204,8 +209,8 @@ http_interactions:
         of wood; wood charcoal; cork and articles of cork; manufactures of straw,
         of esparto or of other plaiting materials; basket-ware and wickerwork (chapters
         44 to 46)","position":9},"chapter":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"wood
-        and articles of wood; wood charcoal"},"heading":{"goods_nomenclature_sid":39988,"goods_nomenclature_item_id":"4400000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"WOOD
-        AND ARTICLES OF WOOD; WOOD CHARCOAL","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"94153","_score":1.4345564,
+        and articles of wood; wood charcoal"},"heading":{"goods_nomenclature_sid":40191,"goods_nomenclature_item_id":"4412000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Plywood,
+        veneered panels and similar laminated wood","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"94153","_score":1.4335179,
         "_source" : {"id":94153,"goods_nomenclature_item_id":"0303510000","producline_suffix":"10","validity_start_date":"2012-01-01T00:00:00+02:00","validity_end_date":null,"description":"Herring
         (Clupea harengus, Clupea pallasii), sardines (Sardina pilchardus, Sardinops|spp.),
         sardinella (Sardinella|spp.), brisling or sprats (Sprattus sprattus), mackerel
@@ -213,8 +218,8 @@ http_interactions:
         mackerel (Trachurus|spp.), cobia (Rachycentron canadum) and swordfish (Xiphias
         gladius), excluding livers and roes","number_indents":1,"section":{"numeral":"I","title":"Live
         animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"fish
-        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"FISH
-        AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"93985","_score":1.0614325,
+        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28590,"goods_nomenclature_item_id":"0303000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Fish,
+        frozen, excluding fish fillets and other fish meat of heading|0304","number_indents":0}}},{"_index":"commodities","_type":"commodity","_id":"93985","_score":1.0605695,
         "_source" : {"id":93985,"goods_nomenclature_item_id":"0302410000","producline_suffix":"10","validity_start_date":"2012-01-01T00:00:00+02:00","validity_end_date":null,"description":"Herring
         (Clupea harengus, Clupea pallasii), anchovies (Engraulis spp.), sardines (Sardina
         pilchardus, Sardinops spp.), sardinella (Sardinella spp.), brisling or sprats
@@ -222,23 +227,23 @@ http_interactions:
         japonicus), jack and horse mackerel (Trachurus spp.), cobia (Rachycentron
         canadum) and swordfish (Xiphias gladius), excluding livers and roes","number_indents":1,"section":{"numeral":"I","title":"Live
         animals; animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"fish
-        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28373,"goods_nomenclature_item_id":"0300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"FISH
-        AND CRUSTACEANS, MOLLUSCS AND OTHER AQUATIC INVERTEBRATES","number_indents":0}}}]}}'
-    http_version:
-  recorded_at: Tue, 09 Oct 2012 07:59:52 GMT
+        and crustaceans, molluscs and other aquatic invertebrates"},"heading":{"goods_nomenclature_sid":28402,"goods_nomenclature_item_id":"0302000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Fish,
+        fresh or chilled, excluding fish fillets and other fish meat of heading|0304","number_indents":0}}}]}}'
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 10:39:29 GMT
 - request:
     method: get
-    uri: http://localhost:9200/search_references/_search?payload%5Bquery%5D%5Bterm%5D%5Btitle%5D=horse&payload%5Bsize%5D=1000000
+    uri: http://localhost:9200/search_references/_search?payload%5Bquery%5D%5Bquery_string%5D%5Banalyzer%5D=snowball&payload%5Bquery%5D%5Bquery_string%5D%5Bfields%5D%5B0%5D=title&payload%5Bquery%5D%5Bquery_string%5D%5Bquery%5D=horse&payload%5Bsize%5D=1000000
     body:
       encoding: US-ASCII
-      string: ! '{"query":{"term":{"title":"horse"}},"size":1000000}'
+      string: ! '{"query":{"query_string":{"fields":["title"],"analyzer":"snowball","query":"horse"}},"size":1000000}'
     headers:
       Accept:
       - ! '*/*; q=0.5, application/xml'
       Accept-Encoding:
       - gzip, deflate
       Content-Length:
-      - '51'
+      - '100'
       User-Agent:
       - Ruby
   response:
@@ -249,33 +254,10 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
-      - '3945'
+      - '124'
     body:
       encoding: US-ASCII
-      string: ! '{"took":217,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":5,"max_score":4.730926,"hits":[{"_index":"search_references","_type":"search_reference","_id":"2949","_score":4.730926,
-        "_source" : {"title":"horse beans","reference":{"id":30726,"goods_nomenclature_item_id":"0713000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Dried
-        leguminous vegetables, shelled, whether or not skinned or split","number_indents":0,"section":{"numeral":"II","title":"Vegetable
-        products (chapters 6 to 14)","position":2},"chapter":{"goods_nomenclature_sid":30240,"goods_nomenclature_item_id":"0700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"edible
-        vegetables and certain roots and tubers"},"class":"Heading"}}},{"_index":"search_references","_type":"search_reference","_id":"2948","_score":4.298147,
-        "_source" : {"title":"horse chestnuts","reference":{"id":35179,"goods_nomenclature_item_id":"2308000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Vegetable
-        materials and vegetable waste, vegetable residues and by-products, whether
-        or not in the form of pellets, of a kind used in animal feeding, not elsewhere
-        specified or included","number_indents":0,"section":{"numeral":"IV","title":"Prepared
-        foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco
-        substitutes (chapters 16 to 24)","position":4},"chapter":{"goods_nomenclature_sid":35125,"goods_nomenclature_item_id":"2300000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"residues
-        and waste from the food industries; prepared animal fodder"},"class":"Heading"}}},{"_index":"search_references","_type":"search_reference","_id":"2950","_score":4.298147,
-        "_source" : {"title":"horse-radish","reference":{"id":30240,"goods_nomenclature_item_id":"0700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"edible
-        vegetables and certain roots and tubers","section":{"numeral":"II","title":"Vegetable
-        products (chapters 6 to 14)","position":2},"class":"Chapter"}}},{"_index":"search_references","_type":"search_reference","_id":"2791","_score":3.0087028,
-        "_source" : {"title":"hair, animal - bovine and horse","reference":{"id":30022,"goods_nomenclature_item_id":"0503000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":"2006-12-31T00:00:00+02:00","description":"Horsehair
-        and horsehair waste, whether or not put up as a layer with or without supporting
-        material","number_indents":0,"section":{"numeral":"I","title":"Live animals;
-        animal products (chapters 1 to 5)","position":1},"chapter":{"goods_nomenclature_sid":30015,"goods_nomenclature_item_id":"0500000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"products
-        of animal origin, not elsewhere specified or included"},"class":"Heading"}}},{"_index":"search_references","_type":"search_reference","_id":"591","_score":2.8388183,
-        "_source" : {"title":"beans - field, including horse and tic","reference":{"id":30726,"goods_nomenclature_item_id":"0713000000","producline_suffix":"80","validity_start_date":"1972-01-01T00:00:00+03:00","validity_end_date":null,"description":"Dried
-        leguminous vegetables, shelled, whether or not skinned or split","number_indents":0,"section":{"numeral":"II","title":"Vegetable
-        products (chapters 6 to 14)","position":2},"chapter":{"goods_nomenclature_sid":30240,"goods_nomenclature_item_id":"0700000000","producline_suffix":"80","validity_start_date":"1971-12-31T00:00:00+03:00","validity_end_date":null,"description":"edible
-        vegetables and certain roots and tubers"},"class":"Heading"}}}]}}'
-    http_version:
-  recorded_at: Tue, 09 Oct 2012 07:59:52 GMT
+      string: ! '{"took":151,"timed_out":false,"_shards":{"total":5,"successful":5,"failed":0},"hits":{"total":0,"max_score":null,"hits":[]}}'
+    http_version: 
+  recorded_at: Thu, 10 Jan 2013 10:39:29 GMT
 recorded_with: VCR 2.2.5


### PR DESCRIPTION
If we have Skateboard as a reference to certain heading searching for
skateboards will also return the same result. This loosens the search criteria a bit.

For deployment we need to do:

```
bundle exec rake tariff:reindex
```

This change is for https://www.pivotaltracker.com/story/show/38974619.
