### PR TITLE
Provide geographical_area_id instead of iso_code.

### DIFF
--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -104,10 +104,6 @@ class GeographicalArea < Sequel::Model
     # TODO: GA22
     # TODO: GA23
   end
-
-  def iso_code
-    geographical_area_id
-  end
 end
 
 

--- a/app/views/api/v1/measures/_measure.json.rabl
+++ b/app/views/api/v1/measures/_measure.json.rabl
@@ -68,14 +68,14 @@ child(measure_conditions: :measure_conditions) do
 end
 
 child(geographical_area: :geographical_area) do
-  attributes :iso_code
+  attributes :geographical_area_id
 
   node(:description) { |ga|
     ga.geographical_area_description.description
   }
 
   child(contained_geographical_areas: :children_geographical_areas) do
-    attributes :iso_code
+    attributes :geographical_area_id
 
     node(:description) { |ga|
       ga.geographical_area_description.description
@@ -84,7 +84,7 @@ child(geographical_area: :geographical_area) do
 end
 
 child(excluded_geographical_areas: :excluded_countries) do
-  node(:iso_code) { |ga|
+  node(:geographical_area_id) { |ga|
     ga.geographical_area_id
   }
   node(:description) { |ga|

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -138,12 +138,4 @@ describe GeographicalArea do
     # GA2 The start date must be less than or equal to the end date.
     it { should validate_validity_dates }
   end
-
-  describe '#iso_code' do
-    let(:geographical_area)                { build :geographical_area, geographical_area_id: 'UK' }
-
-    it 'is an alias to geographical area id' do
-      geographical_area.iso_code.should == 'UK'
-    end
-  end
 end


### PR DESCRIPTION
Geographical area id is not always an iso code. It's iso code for
countries, but otherwise it's geographical area group id. So it should
be up to client app to decide when to call this an iso code.

Since the API will be public one day, it is best to expose Taric structure and not invent our own names. There may be other places where such refactorings are needed.
