### PR TITLE
Present order_number: { } as Hash on Measure.

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -587,6 +587,14 @@ class Measure < Sequel::Model
   def associated_to_non_open_ended_gono?
     goods_nomenclature.present? && goods_nomenclature.validity_end_date.present?
   end
+
+  def order_number
+    if quota_order_number.present?
+      quota_order_number
+    elsif ordernumber.present?
+      QuotaOrderNumber.new(quota_order_number_id: ordernumber)
+    end
+  end
 end
 
 

--- a/app/views/api/v1/measures/_measure.json.rabl
+++ b/app/views/api/v1/measures/_measure.json.rabl
@@ -1,6 +1,5 @@
 attributes :measure_sid,
            :origin,
-           :ordernumber,
            :effective_start_date,
            :effective_end_date,
            :measure_type_id,
@@ -113,7 +112,7 @@ node(:additional_code, if: ->(measure) { measure.export_refund_nomenclature_sid.
   }
 end
 
-child(quota_order_number: :order_number) do
+child(order_number: :order_number) do
   node(:number) { |qon| qon.quota_order_number_id }
 
   child(quota_definition: :definition) do
@@ -130,4 +129,3 @@ child(quota_order_number: :order_number) do
     node(:blocking_period_end_date) { |qd| qd.last_blocking_period.try(:blocking_end_date) }
   end
 end
-


### PR DESCRIPTION
It used to have two presentations, as string - when it had no definition
and as Hash & String when with definition. 

Order numbers may have no definition. In that case users are advised to contact Rural Payments Agency.
