### PR TITLE
Fix TariffSynchronizer's ChiefUpdate fetching for new year.

### DIFF
--- a/db/migrate/20130121114856_clear_invalid_chief_updates.rb
+++ b/db/migrate/20130121114856_clear_invalid_chief_updates.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  up do
+    run "DELETE FROM `tariff_updates` WHERE ((`tariff_updates`.`update_type` IN ('TariffSynchronizer::ChiefUpdate')) AND (`issue_date` >= '2013-01-01') AND (`state` = 'M'))"
+  end
+
+  down do
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1557,6 +1557,7 @@ Sequel.migration do
     self[:schema_migrations].insert(:filename => "20121204143748_add_hidden_commodities.rb")
     self[:schema_migrations].insert(:filename => "20130108084950_update_footnotes_04005_04018.rb")
     self[:schema_migrations].insert(:filename => "20130108131537_remove_links_from_04005_04018.rb")
+    self[:schema_migrations].insert(:filename => "20130121114856_clear_invalid_chief_updates.rb")
 
     create_table(:search_references) do
       primary_key :id, :type=>"int(11)"

--- a/lib/chief_transformer/operations/tame_operation.rb
+++ b/lib/chief_transformer/operations/tame_operation.rb
@@ -15,7 +15,14 @@ class ChiefTransformer
                .with_tariff_measure_number(tame.tar_msr_no)
                .not_terminated
                .each do |measure|
-          measure.update validity_end_date: tame.fe_tsmp
+          end_date = if (measure.associated_to_non_open_ended_gono? &&
+                         record.fe_tsmp > measure.goods_nomenclature_validity_end_date)
+                       measure.goods_nomenclature_validity_end_date
+                     else
+                       record.fe_tsmp
+                     end
+
+          measure.update validity_end_date: end_date
         end
       end
 

--- a/lib/tariff_synchronizer/chief_update.rb
+++ b/lib/tariff_synchronizer/chief_update.rb
@@ -44,7 +44,9 @@ module TariffSynchronizer
     private
 
     def self.chief_file_name_for(date)
-      "KBT009(#{date.strftime("%y")}#{date.yday}).txt"
+      day = sprintf("%03d", date.yday)
+
+      "KBT009(#{date.strftime("%y")}#{day}).txt"
     end
 
     def self.chief_update_url_for(date)

--- a/spec/support/synchronizer_helper.rb
+++ b/spec/support/synchronizer_helper.rb
@@ -55,7 +55,8 @@ module SynchronizerHelper
       "ZZZZZZZZZZZ","31/12/9999:23:59:59"," ",434,
     }
 
-    chief_file_path = File.join(TariffSynchronizer.root_path, 'chief', "#{date}_KBT009(#{date.strftime("%y")}#{date.yday}).txt")
+    day = sprintf('%03d', date.yday)
+    chief_file_path = File.join(TariffSynchronizer.root_path, 'chief', "#{date}_KBT009(#{date.strftime("%y")}#{day}).txt")
     create_file chief_file_path, content
 
     Pathname.new(chief_file_path)

--- a/spec/unit/tariff_synchronizer/chief_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/chief_update_spec.rb
@@ -10,7 +10,7 @@ describe TariffSynchronizer::ChiefUpdate do
     let(:blank_response)     { build :response, content: nil }
     let(:not_found_response) { build :response, :not_found }
     let(:success_response)   { build :response, :success, content: 'abc' }
-    let(:update_name)        { "KBT009(101).txt" }
+    let(:update_name)        { "KBT009(10001).txt" }
     let(:url)                { "#{TariffSynchronizer.host}/taric/#{update_name}" }
 
 


### PR DESCRIPTION
While working on 2nd and 3rd national measurement units I noticed that we dont' have any CHIEF updates for this year. It appears that CHIEF file update names are formed with leading zeroes. So update for 1st of 2013 is KBT009(13001).txt. This change fixes the issue by removing all missing CHIEF updates for this year so that they could be downloaded and applied again (all of the days actually had update files).

While applying those updates I encountered an issue with TAME deletion, so I applied same fix as for MFCM deletion (see https://github.com/alphagov/trade-tariff-backend/blob/master/lib/chief_transformer/operations/mfcm_delete.rb), so that national measures would still comply to conformance validations.

We need to run:

```
bundle exec rake tariff:sync:apply
```

after the update gets deployed.

Lately there have been updates to backend that impact frontend, so frontend needs deployment too.
