### PR TITLE
Send warning email if several updates in a row are missing.

### DIFF
--- a/app/views/tariff_synchronizer/mailer/missing_updates.html.erb
+++ b/app/views/tariff_synchronizer/mailer/missing_updates.html.erb
@@ -1,0 +1,5 @@
+<p>Hello,</p>
+
+<p>
+Trade Tariff found <%= @count %> <%= @update_type.upcase %> updates in a row to be missing.
+</p>

--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -40,7 +40,6 @@ module TariffSynchronizer
   autoload :TaricArchive,  "tariff_synchronizer/taric_archive"
   autoload :ChiefArchive,  "tariff_synchronizer/chief_archive"
 
-
   extend self
 
   mattr_accessor :username
@@ -81,6 +80,10 @@ module TariffSynchronizer
   # Taric update url template
   mattr_accessor :taric_update_url_template
   self.taric_update_url_template = "%{host}/taric/%{file_name}"
+
+  # Number of days to warn about missing updates after
+  mattr_accessor :warning_day_count
+  self.warning_day_count = 3
 
   # Download pending updates for Taric and National data
   # Gets latest downloaded file present in (inbox/failbox/processed) and tries

--- a/lib/tariff_synchronizer/logger.rb
+++ b/lib/tariff_synchronizer/logger.rb
@@ -124,6 +124,15 @@ module TariffSynchronizer
     def delay_download(event)
       info "Delaying update fetching: #{event.payload[:url]}"
     end
+
+    # We missed three update files in a row
+    # Might be okay for Taric, but most likely not ok for CHIEF
+    # this is precautionary measure
+    def missing_updates(event)
+      warn "Missing #{event.payload[:count]} updates in a row for #{event.payload[:update_type].to_s.upcase}"
+
+      Mailer.missing_updates(event.payload[:count], event.payload[:update_type].to_s).deliver
+    end
   end
 end
 

--- a/lib/tariff_synchronizer/mailer.rb
+++ b/lib/tariff_synchronizer/mailer.rb
@@ -50,5 +50,12 @@ module TariffSynchronizer
 
       mail subject: "[info] Tariff updates applied #{environment_indicator}"
     end
+
+    def missing_updates(count, update_type)
+      @count = count
+      @update_type = update_type
+
+      mail subject: "[warn] Missing #{count} #{update_type.upcase} updates in a row #{environment_indicator}"
+    end
   end
 end

--- a/spec/factories/chief_record_factory.rb
+++ b/spec/factories/chief_record_factory.rb
@@ -343,6 +343,10 @@ FactoryGirl.define do
     trait :failed do
       state { 'F' }
     end
+
+    trait :missing do
+      state { 'M' }
+    end
   end
 
   factory :chief_update, parent: :base_update, class: TariffSynchronizer::ChiefUpdate do

--- a/spec/unit/tariff_synchronizer/chief_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/chief_update_spec.rb
@@ -109,6 +109,26 @@ describe TariffSynchronizer::ChiefUpdate do
     end
   end
 
+  describe '.sync' do
+    let(:not_found_response) { build :response, :not_found }
+
+    context 'file not found for nth time in a row' do
+      let!(:chief_update1) { create :chief_update, :missing, issue_date: Date.today.ago(2.days) }
+      let!(:chief_update2) { create :chief_update, :missing, issue_date: Date.today.ago(3.days) }
+      let!(:stub_logger)   { stub }
+
+      before {
+        TariffSynchronizer::ChiefUpdate.stubs(:download_content)
+                                       .returns(not_found_response)
+      }
+
+      it 'notifies about several missing updates in a row' do
+        TariffSynchronizer::ChiefUpdate.expects(:notify_about_missing_updates).returns(true)
+        TariffSynchronizer::ChiefUpdate.sync
+      end
+    end
+  end
+
   describe "#apply" do
     let(:example_date) { Forgery(:date).date }
     let(:state) { :pending }

--- a/spec/unit/tariff_synchronizer/taric_update_spec.rb
+++ b/spec/unit/tariff_synchronizer/taric_update_spec.rb
@@ -204,6 +204,25 @@ describe TariffSynchronizer::TaricUpdate do
     after  { purge_synchronizer_folders }
   end
 
+  describe '.sync' do
+    let(:not_found_response) { build :response, :not_found }
+
+    context 'file not found for nth time in a row' do
+      let!(:taric_update1) { create :taric_update, :missing, issue_date: Date.today.ago(2.days) }
+      let!(:taric_update2) { create :taric_update, :missing, issue_date: Date.today.ago(3.days) }
+
+      before {
+        TariffSynchronizer::TaricUpdate.stubs(:download_content)
+                                       .returns(not_found_response)
+      }
+
+      it 'notifies about several missing updates in a row' do
+        TariffSynchronizer::TaricUpdate.expects(:notify_about_missing_updates).returns(true)
+        TariffSynchronizer::TaricUpdate.sync
+      end
+    end
+  end
+
   describe "#apply" do
     let(:state) { :pending }
     let!(:example_taric_update) { create :taric_update, example_date: example_date }


### PR DESCRIPTION
Sends a warning email after sync if 3 last TARIC or CHIEF updates in a row are missing.
