### PR TITLE
Prevent sending false success messages.

### DIFF
--- a/lib/tariff_synchronizer/logger.rb
+++ b/lib/tariff_synchronizer/logger.rb
@@ -25,9 +25,7 @@ module TariffSynchronizer
     def apply(event)
       info "Finished applying updates"
 
-      if !event.payload.has_key?(:exception) && event.payload[:count] > 0
-        Mailer.applied(event.payload[:count]).deliver
-      end
+      Mailer.applied(event.payload[:count]).deliver
     end
 
     # Update failed to be applied

--- a/spec/unit/tariff_synchronizer/logger_spec.rb
+++ b/spec/unit/tariff_synchronizer/logger_spec.rb
@@ -65,8 +65,6 @@ describe TariffSynchronizer::Logger do
   end
 
   describe '#apply logging' do
-    let!(:chief_update) { create :chief_update }
-
     before {
       TariffSynchronizer.apply
     }


### PR DESCRIPTION
This prevents false success emails from being sent. 'applied' notification would never contain an exception as it is being caught inside the update application loop. Notifications about failed updates are being sent by other notifications so there is no reason to duplicate that.

Success email will be sent only if there will be no pending or failed update after update application process.
