### PR TITLE
Only notify when work has been done

### DIFF
--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -138,7 +138,7 @@ module TariffSynchronizer
         end
       end
 
-      ActiveSupport::Notifications.instrument("apply.tariff_synchronizer", count: pending_update_count) if BaseUpdate.pending_or_failed.none?
+      ActiveSupport::Notifications.instrument("apply.tariff_synchronizer", count: pending_update_count) if pending_update_count && BaseUpdate.pending_or_failed.none?
     end
   end
 


### PR DESCRIPTION
Don't bother sending emails saying

"Trade Tariff successfully applied 0 update(s)"

if there were no updates to be actioned.
