### PR TITLE
Remove successful transformation email.

### DIFF
--- a/app/views/chief_transformer/mailer/successful_transformation_notice.html.erb
+++ b/app/views/chief_transformer/mailer/successful_transformation_notice.html.erb
@@ -1,5 +1,0 @@
-<p>Hello,</p>
-
-<p>
-  Trade Tariff successfully transformed pending CHIEF records at <%= Time.now %>.
-</p>

--- a/lib/chief_transformer/logger.rb
+++ b/lib/chief_transformer/logger.rb
@@ -8,15 +8,6 @@ class ChiefTransformer
       info "CHIEF Transformer started in #{event.payload[:mode]} mode"
     end
 
-    def transform(event)
-      if event.payload.has_key?(:exception)
-        error "CHIEF Transformer failed #{event.payload[:exception]}"
-      else
-        info "CHIEF Transformer finished successfully in #{event.duration}s"
-        Mailer.successful_transformation_notice.deliver
-      end
-    end
-
     def process(event)
       unless event.payload.has_key?(:exception)
         info "Processed: #{event.payload[:operation].inspect}"

--- a/lib/chief_transformer/mailer.rb
+++ b/lib/chief_transformer/mailer.rb
@@ -5,10 +5,6 @@ class ChiefTransformer
     default from: "DO NOT REPLY <trade-tariff-alerts@digital.cabinet-office.gov.uk>",
             to: TradeTariffBackend.admin_email
 
-    def successful_transformation_notice
-      mail subject: "[info] Successful CHIEF transformation #{environment_indicator}"
-    end
-
     def failed_transformation_notice(operation, exception, model, errors)
       @operation = operation
       @exception = exception

--- a/spec/unit/chief_transformer/logger_spec.rb
+++ b/spec/unit/chief_transformer/logger_spec.rb
@@ -24,19 +24,6 @@ describe ChiefTransformer::Logger do
   describe '#transform logging' do
     before { ChiefTransformer.instance.invoke }
 
-    context 'successuful transformation' do
-      it 'logs and info event' do
-        @logger.logged(:info).size.should be >= 1
-        @logger.logged(:info).last.should =~ /finished successfull/
-      end
-
-      it 'sends an info email to the administrator' do
-        ActionMailer::Base.deliveries.should_not be_empty
-        email = ActionMailer::Base.deliveries.last
-        email.encoded.should =~ /successfully transformed/
-      end
-    end
-
     context 'transformation with errors' do
       let!(:tame)    { create :tame, :unprocessed }
       let!(:measure) { create :measure }
@@ -49,8 +36,8 @@ describe ChiefTransformer::Logger do
       }
 
       it 'logs an error event' do
-        @logger.logged(:error).size.should be >= 2
-        @logger.logged(:error).last.should =~ /transformer failed/i
+        @logger.logged(:error).size.should eq 1
+        @logger.logged(:error).last.should =~ /Could not transform/i
       end
 
       it 'sends an error email' do


### PR DESCRIPTION
It made sense when application and transformation were run separately. Now success email from synchronizer means that CHIEF update successfully transformed too, so there is no reason to keep this.
