### PR TITLE
Do not apply subsequent updates if one failed.

### DIFF
--- a/lib/tariff_synchronizer.rb
+++ b/lib/tariff_synchronizer.rb
@@ -122,7 +122,11 @@ module TariffSynchronizer
               ActiveSupport::Notifications.instrument("failed_update.tariff_synchronizer", exception: exception,
                                                                                            update: pending_update)
 
-              raise Sequel::Rollback
+              pending_update.mark_as_failed
+
+              # re-raise to end application process here
+              # Sequel transaction gets rolled back too
+              raise exception
             end
           end
         end

--- a/lib/tariff_synchronizer/base_update.rb
+++ b/lib/tariff_synchronizer/base_update.rb
@@ -57,6 +57,10 @@ module TariffSynchronizer
       update(state: APPLIED_STATE)
     end
 
+    def mark_as_failed
+      update(state: FAILED_STATE)
+    end
+
     def file_path
       File.join(TariffSynchronizer.root_path, self.class.update_type.to_s, filename)
     end

--- a/lib/tariff_synchronizer/pending_update.rb
+++ b/lib/tariff_synchronizer/pending_update.rb
@@ -3,7 +3,8 @@ module TariffSynchronizer
     attr_reader :update,
                 :file_name
 
-    delegate :apply, :file_path, :issue_date, :update_type, :update_priority, to: :update
+    delegate :apply, :file_path, :issue_date, :update_type,
+             :update_priority, :mark_as_failed, to: :update
 
     def initialize(update)
       @file_name = update.filename


### PR DESCRIPTION
Sequel::Rollback gets caught by Sequel.transaction block so all
subsequent updates were applied. Now we just mark update as failed and re-raise
the exception to end the process.

Apply task won't run and will send an error message if there are any
failed updates, see https://github.com/alphagov/trade-tariff-backend/blob/cd87056e7a0216560a3eec6497c8faace15f65c5/lib/tariff_synchronizer.rb#L105.
