### PR TITLE
Expose first national quantity with national measurement unit set.

### DIFF
--- a/app/models/national_measurement_unit_set.rb
+++ b/app/models/national_measurement_unit_set.rb
@@ -2,21 +2,28 @@ class NationalMeasurementUnitSet < Sequel::Model
   plugin :time_machine
 
   set_dataset db[:chief_comm].
-              select(Sequel.as(:tbl91__tbl_code, :second_quantity_code)).
-              select_more(Sequel.as(:tbl92__tbl_code, :third_quantity_code)).
-              select_more(Sequel.as(:tbl91__tbl_txt, :second_quantity_description)).
-              select_more(Sequel.as(:tbl92__tbl_txt, :third_quantity_description)).
-              join_table(:left, :chief_tbl9, {tbl91__tbl_code: :chief_comm__uoq_code_cdu2,
+              select(Sequel.as(:tbl91__tbl_code, :first_quantity_code)).
+              select_more(Sequel.as(:tbl92__tbl_code, :second_quantity_code)).
+              select_more(Sequel.as(:tbl93__tbl_code, :third_quantity_code)).
+              select_more(Sequel.as(:tbl91__tbl_txt, :first_quantity_description)).
+              select_more(Sequel.as(:tbl92__tbl_txt, :second_quantity_description)).
+              select_more(Sequel.as(:tbl93__tbl_txt, :third_quantity_description)).
+              join_table(:left, :chief_tbl9, {tbl91__tbl_code: :chief_comm__uoq_code_cdu1,
                                               tbl91__tbl_type: 'UNOQ'}, table_alias: :tbl91).
-              join_table(:left, :chief_tbl9, {tbl92__tbl_code: :chief_comm__uoq_code_cdu3,
+              join_table(:left, :chief_tbl9, {tbl92__tbl_code: :chief_comm__uoq_code_cdu2,
                                               tbl92__tbl_type: 'UNOQ'}, table_alias: :tbl92).
-              filter{~{chief_comm__uoq_code_cdu2: nil} | ~{chief_comm__uoq_code_cdu3: nil}}.
+              join_table(:left, :chief_tbl9, {tbl93__tbl_code: :chief_comm__uoq_code_cdu3,
+                                              tbl93__tbl_type: 'UNOQ'}, table_alias: :tbl93).
+              filter{~{chief_comm__uoq_code_cdu1: nil} | ~{chief_comm__uoq_code_cdu2: nil} | ~{chief_comm__uoq_code_cdu3: nil}}.
               order(:chief_comm__audit_tsmp.desc)
 
   set_primary_key  :tbl_code
 
   def national_measurement_unit_set_units
-    [NationalMeasurementUnit.new(measurement_unit_code: second_quantity_code,
+    [NationalMeasurementUnit.new(measurement_unit_code: first_quantity_code,
+                                 description: first_quantity_description,
+                                 level: 1),
+     NationalMeasurementUnit.new(measurement_unit_code: second_quantity_code,
                                  description: second_quantity_description,
                                  level: 2),
      NationalMeasurementUnit.new(measurement_unit_code: third_quantity_code,

--- a/spec/models/national_measurement_unit_set_spec.rb
+++ b/spec/models/national_measurement_unit_set_spec.rb
@@ -4,8 +4,10 @@ describe NationalMeasurementUnitSet do
   describe "#national_measurement_unit_set_units" do
     let(:tbl1) { create :tbl9, :unoq }
     let(:tbl2) { create :tbl9, :unoq }
-    let(:comm) { create :comm, uoq_code_cdu2: tbl1.tbl_code,
-                               uoq_code_cdu3: tbl2.tbl_code }
+    let(:tbl3) { create :tbl9, :unoq }
+    let(:comm) { create :comm, uoq_code_cdu1: tbl1.tbl_code,
+                               uoq_code_cdu2: tbl2.tbl_code,
+                               uoq_code_cdu3: tbl3.tbl_code }
 
     let(:nmus) { NationalMeasurementUnitSet.where(cmdty_code: comm.cmdty_code).first }
 
@@ -17,17 +19,24 @@ describe NationalMeasurementUnitSet do
       nmus.national_measurement_unit_set_units.all?{ |nmusu| nmusu.is_a?(NationalMeasurementUnit) }
     end
 
-    it 'should set second national measurement unit code/description to comm uoq_code_cdu2' do
+    it 'should set first national measurement unit code/description to comm uoq_code_cdu1' do
       nmusu = nmus.national_measurement_unit_set_units.first
       nmusu.measurement_unit_code.should eq tbl1.tbl_code
       nmusu.description.should eq tbl1.tbl_txt
+      nmusu.level.should eq 1
+    end
+
+    it 'should set second national measurement unit code/description to comm uoq_code_cdu2' do
+      nmusu = nmus.national_measurement_unit_set_units.second
+      nmusu.measurement_unit_code.should eq tbl2.tbl_code
+      nmusu.description.should eq tbl2.tbl_txt
       nmusu.level.should eq 2
     end
 
     it 'should set second national measurement unit code/description to comm uoq_code_cdu3' do
       nmusu = nmus.national_measurement_unit_set_units.last
-      nmusu.measurement_unit_code.should eq tbl2.tbl_code
-      nmusu.description.should eq tbl2.tbl_txt
+      nmusu.measurement_unit_code.should eq tbl3.tbl_code
+      nmusu.description.should eq tbl3.tbl_txt
       nmusu.level.should eq 3
     end
   end


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/43643287.

When transforming CHIEF we do map its units to TARIC units. Sometimes this yields unexpected results and duplications. So now for excise measures we're just showing national quantity units that are unique.
