### PR TITLE
Allow to search for 08 and 09 (Chapters 8 and 9).

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -36,7 +36,7 @@ class SearchService
       @results = case query_string
                  when /^[0-9]{1,3}$/
                    Chapter.actual
-                          .by_code(sprintf("%02d",query_string.to_s))
+                          .by_code(query_string.to_s.rjust(2, '0'))
                           .non_hidden
                           .first
                  when /^[0-9]{4,9}$/

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -58,7 +58,7 @@ describe SearchService do
       end
 
       context 'chapter goods code id has got preceding zero' do
-        let(:chapter) { create :chapter, goods_nomenclature_item_id: '0100000000' }
+        let(:chapter) { create :chapter, goods_nomenclature_item_id: '0800000000' }
         let(:pattern) {
           {
             type: 'exact_match',


### PR DESCRIPTION
Currently search will fail when searching for '08' and '09' (Chapter 8 and 9). I'm not entirely sure why, but:

``` ruby
~ (main) > sprintf("%02d", "7")
=> "07"
~ (main) > sprintf("%02d", "8")
=> "08"
~ (main) > sprintf("%02d", "07")
=> "07"
~ (main) > sprintf("%02d", "08")
ArgumentError: invalid value for Integer(): "08"
from (pry):4:in `sprintf'
~ (main) > sprintf("%02d", "09")
ArgumentError: invalid value for Integer(): "09"
from (pry):5:in `sprintf'
~ (main) > sprintf("%02d", "10")
=> "10"
```

So this change fixes it.
