### PR TITLE
Fix Chief mappings to hectolitre.

### DIFF
--- a/app/models/chief/tamf.rb
+++ b/app/models/chief/tamf.rb
@@ -45,12 +45,8 @@ module Chief
     end
 
     def measurement_unit(cmpd_uoq, uoq)
-      if cmpd_uoq.present?
-        Chief::MeasurementUnit.where(spfc_cmpd_uoq: cmpd_uoq,
-                                     spfc_uoq: uoq).first
-      elsif uoq.present?
-        Chief::MeasurementUnit.where(spfc_uoq: uoq).first
-      end
+      Chief::MeasurementUnit.where(spfc_cmpd_uoq: cmpd_uoq,
+                                   spfc_uoq: uoq).first
     end
 
     def geographical_area

--- a/db/migrate/20130212144512_fix_chief_hectolitre_mappings.rb
+++ b/db/migrate/20130212144512_fix_chief_hectolitre_mappings.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  up do
+    run "UPDATE measure_components SET measurement_unit_code='HLT', measurement_unit_qualifier_code=NULL WHERE measurement_unit_code='ASX' AND measurement_unit_qualifier_code = 'X'"
+  end
+
+  down do
+    # this is not reversible and should not be
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1627,6 +1627,7 @@ Sequel.migration do
     self[:schema_migrations].insert(:filename => "20130124080334_add_comm_tbl9_indexes.rb")
     self[:schema_migrations].insert(:filename => "20130124085812_fix_chief_field_lengths.rb")
     self[:schema_migrations].insert(:filename => "20130130132054_add_hydrocarbon_oils_footnote.rb")
+    self[:schema_migrations].insert(:filename => "20130212144512_fix_chief_hectolitre_mappings.rb")
 
     create_table(:search_references) do
       primary_key :id, :type=>"int(11)"

--- a/spec/models/chief/tamf_spec.rb
+++ b/spec/models/chief/tamf_spec.rb
@@ -45,24 +45,21 @@ describe Chief::Tamf do
   end
 
   describe '#measurement_unit' do
+    let!(:chief_measurement_unit1) { create :chief_measurement_unit, spfc_cmpd_uoq: '12',
+                                                                    spfc_uoq: '13' }
+    let!(:chief_measurement_unit2) { create :chief_measurement_unit, spfc_cmpd_uoq: nil,
+                                                                    spfc_uoq: '13' }
     let(:tamf) { build :tamf }
 
     context 'cmpd_uoq present' do
       it 'fetches Chief::MeasurementUnit with cmpd_uoq as part of the key' do
-        Chief::MeasurementUnit.expects(:where).with(spfc_cmpd_uoq: 'abc',
-                                                    spfc_uoq: 'def').returns(stub_everything)
-
-        tamf.measurement_unit('abc', 'def')
+        tamf.measurement_unit('12', '13').should eq chief_measurement_unit1
       end
     end
 
     context 'cmpd_uoq blank' do
       it 'fetches Chief::MeasurementUnit with uoq as key' do
-        Chief::MeasurementUnit.expects(:where)
-                              .with(spfc_uoq: 'abc')
-                              .returns(stub_everything)
-
-        tamf.measurement_unit(nil, 'abc')
+        tamf.measurement_unit(nil, '13').should eq chief_measurement_unit2
       end
     end
   end


### PR DESCRIPTION
This fixes missing CHIEF measurement units for Excise 412 measures.

Examples:
https://tariff.preview.alphagov.co.uk/trade-tariff/commodities/2204291000#import
https://tariff.preview.alphagov.co.uk/trade-tariff/commodities/2205101000#import

Some national measures do not have measurement units which should be Hectolitre.
