### PR TITLE
Prevent access to non declarable commodities.

### DIFF
--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -42,6 +42,7 @@ module Api
                               .by_code(params[:id])
                               .take
 
+        raise Sequel::RecordNotFound if @commodity.children.any?
         raise Sequel::RecordNotFound if @commodity.goods_nomenclature_item_id.in? HiddenGoodsNomenclature.codes
       end
     end

--- a/lib/sequel/plugins/time_machine.rb
+++ b/lib/sequel/plugins/time_machine.rb
@@ -6,6 +6,8 @@ module Sequel
       def self.configure(model, opts={})
         model.period_start_date_column = opts[:period_start_column]
         model.period_end_date_column = opts[:period_end_column]
+
+        model.delegate :point_in_time, to: model
       end
 
       module ClassMethods


### PR DESCRIPTION
This does not have a story, but has a ZenDesk ticket #63221. https://www.gov.uk/trade-tariff/commodities/3903909000 Should not be accessable as 3903909000 is an intermediate line, not a declarable commodity see https://www.gov.uk/trade-tariff/headings/3903. It's either that a search engine indexed these, or someone tried to enter code manually.

Children/ancestor code is pending refactoring, but I'm not sure how to do that better at this time, these codes do not follow any logical sequence.
