### PR TITLE
Remove [ and ] characters from search term.

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -56,7 +56,8 @@ class SearchService
     @t = if term =~ /^(?!.*[A-Za-z]+).*$/
            term.scan(/\d+/).join
          else
-           term
+           # ignore [ and ] characters to avoid range searches
+           term.to_s.gsub(/(\[|\])/,'')
          end
   end
 

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -7,6 +7,10 @@ describe SearchService do
     it 'assigns search query' do
       SearchService.new(t: query).t.should == query
     end
+
+    it 'strips [, ] characters from search query' do
+      SearchService.new(t: '[hello] [world]').t.should == 'hello world'
+    end
   end
 
   describe "#valid?" do


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/44710559.

Ignores '[' and ']' in the search term as they are meant to do range searches and we don't have any ranges.

After deployment we should see the same results for 'water' and 'w[a[t[e]r]'.
