### PR TITLE
Disable conformance validations for Mfmc update

### DIFF
--- a/lib/chief_transformer/operations/mfcm_update.rb
+++ b/lib/chief_transformer/operations/mfcm_update.rb
@@ -9,7 +9,8 @@ class ChiefTransformer
                  .with_gono_id(record.cmdty_code)
                  .valid_to(record.le_tsmp)
                  .each do |measure|
-                   measure.update validity_end_date: record.le_tsmp
+                   measure.validity_end_date = record.le_tsmp
+                   measure.save(validate: false)
                  end
         else
           if Measure.with_measure_type(record.measure_type)

--- a/spec/integration/chief_transformer/custom_spec.rb
+++ b/spec/integration/chief_transformer/custom_spec.rb
@@ -173,4 +173,43 @@ describe 'CHIEF: Custom scenarions' do
       measure.validity_end_date.should_not eq tame.fe_tsmp
     end
   end
+
+  describe 'Scenario: MFCM update fails due to conformance validation (ME8)' do
+    let!(:gono) { create :goods_nomenclature, :with_indent,
+                                             goods_nomenclature_sid: 91900,
+                                             goods_nomenclature_item_id: '5607509090',
+                                             producline_suffix: 80,
+                                             validity_start_date: Date.new(2010,1,1),
+                                             validity_end_date: Date.new(2013,02,28) }
+    let!(:measure) { create :measure, :national, measure_sid: -41534,
+                                                 measure_type: 'VTS',
+                                                 goods_nomenclature_item_id: '5607509090',
+                                                 goods_nomenclature_sid: 91900,
+                                                 validity_start_date: DateTime.new(2007,10,1,0,0),
+                                                 validity_end_date: Date.new(2013,2,28),
+                                                 tariff_measure_number: '12110985' }
+
+    let!(:mfcm) { create :mfcm, msrgp_code: 'VT',
+                                msr_type: 'S',
+                                tty_code: 'B00',
+                                fe_tsmp: DateTime.new(2013,5,14,14,14),
+                                le_tsmp: DateTime.new(2013,5,14,14,28),
+                                cmdty_code: '5607509090',
+                                tar_msr_no: nil,
+                                amend_indicator: 'U'
+    }
+
+
+    let!(:measure_type) { create :measure_type, measure_type_id: 'VTS', validity_start_date: Date.today.ago(10.years) }
+
+    it 'will not raise validation exception' do
+      expect { ChiefTransformer.instance.invoke }.not_to raise_error ChiefTransformer::TransformException
+    end
+
+    it 'will update measure validity dates' do
+      ChiefTransformer.instance.invoke
+
+      measure.reload.validity_end_date.should eq mfcm.le_tsmp
+    end
+  end
 end


### PR DESCRIPTION
This is meant to solve CHIEF update application problem that appeared today (15th of May 2013). I.e.:

```
Operation:

  #<Chief::Mfcm @values={:fe_tsmp=>2013-05-14 14:14:00 +0000, :msrgp_code=>"VT", :msr_type=>"S", :tty_code=>"B00", :le_tsmp=>2013-05-14 14:28:00 +0000, :audit_tsmp=>2013-05-14 14:13:00 +0000, :cmdty_code=>"5607509090", :cmdty_msr_xhdg=>"N", :null_tri_rqd=>"N", :exports_use_ind=>false, :tar_msr_no=>nil, :processed=>false, :amend_indicator=>"U", :origin=>"2013-05-15_KBT009(13135).txt"}>
Model:

    #<Measure @values={:measure_sid=>-41534, :measure_type=>"VTS", :geographical_area=>"1011", :goods_nomenclature_item_id=>"5607509090", :validity_start_date=>2007-10-01 00:00:00 +0000, :validity_end_date=>2013-05-14 14:28:00 +0000, :measure_generating_regulation_role=>1, :measure_generating_regulation_id=>"IYY99990", :justification_regulation_role=>nil, :justification_regulation_id=>nil, :stopped_flag=>false, :geographical_area_sid=>400, :goods_nomenclature_sid=>70762, :ordernumber=>nil, :additional_code_type=>nil, :additional_code=>nil, :additional_code_sid=>nil, :reduction_indicator=>nil, :export_refund_nomenclature_sid=>nil, :created_at=>2012-12-12 12:00:07 +0000, :updated_at=>nil, :national=>true, :tariff_measure_number=>nil, :invalidated_by=>nil, :invalidated_at=>nil}>

Errors:

    {:goods_nomenclature=>["Commodity does not span validity date of Measure"]}

Exception

  goods_nomenclature Commodity does not span validity date of Measure
```

I think we should not be performing conformance validations on national data at all. It is just not meant to be validated. This is one of those times when Taric and CHIEF data collides. This is the first change that goes in this direction, we may need to review ChiefTransformer and do more testing.

We had a case when Taric adds validity end date to Commodity and makes associated national measures invalid. This time CHIEF tries to extend Measure validity period on a national measure and this period spans beyond associated Goods code validity period and this breaks conformance validation. I think it's evident that neither CHIEF maintainers  pay much attention to what's happening in Taric and how that impacts CHIEF records nor of course the other way around. So I think we should just not force the impossible to happen. Extension of measure validity period should not have much impact anyway, because we won't show Goods code after it's validity period end. Any thoughts about all this?
