### PR TITLE
Disable cron

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,8 +1,8 @@
 set :output, { error: 'log/cron.error.log', standard: 'log/cron.log'}
 
-every 1.hour do
-  rake "tariff:sync:apply"
-end
+# every 1.hour do
+#   rake "tariff:sync:apply"
+# end
 
 every 1.day, at: '10pm' do
   rake "tariff:support:clean_national_measures"


### PR DESCRIPTION
Precaution after we received bad data from a transfer. Don't want
to potentially corrupt the current database.
