### PR TITLE
Fix commodity ancestor selection

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -53,19 +53,21 @@ class Commodity < GoodsNomenclature
              :goods_nomenclature_descriptions)
       .join_table(:inner,
         GoodsNomenclatureIndent
-                 .select(Sequel.as(:goods_nomenclatures__goods_nomenclature_sid, :gono_sid),
-                         Sequel.as(:max.sql_function(:goods_nomenclatures__goods_nomenclature_item_id), :max_gono),
+                 .select(:goods_nomenclature_indents__goods_nomenclature_sid,
+                         :goods_nomenclature_indents__goods_nomenclature_item_id,
                          :goods_nomenclature_indents__number_indents)
                  .with_actual(GoodsNomenclature)
                  .join(:goods_nomenclatures, goods_nomenclature_indents__goods_nomenclature_sid: :goods_nomenclatures__goods_nomenclature_sid)
                  .where("goods_nomenclature_indents.goods_nomenclature_item_id LIKE ?", heading_id)
                  .where("goods_nomenclature_indents.goods_nomenclature_item_id <= ?", goods_nomenclature_item_id)
-                 .where("goods_nomenclature_indents.number_indents < ?", goods_nomenclature_indent.number_indents)
                  .order(:goods_nomenclature_indents__validity_start_date.desc,
                         :goods_nomenclature_indents__goods_nomenclature_item_id.desc)
-                 .group(:goods_nomenclature_indents__goods_nomenclature_sid),
-        { t1__gono_sid: :goods_nomenclatures__goods_nomenclature_sid,
-          t1__max_gono: :goods_nomenclatures__goods_nomenclature_item_id })
+                 .from_self
+                 .group(:goods_nomenclature_sid)
+                 .from_self
+                 .where("number_indents < ?", goods_nomenclature_indent.number_indents),
+        { t1__goods_nomenclature_sid: :goods_nomenclatures__goods_nomenclature_sid,
+          t1__goods_nomenclature_item_id: :goods_nomenclatures__goods_nomenclature_item_id })
       .order(:goods_nomenclatures__goods_nomenclature_item_id.desc)
       .all
       .group_by(&:number_indents)

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -266,4 +266,33 @@ describe Commodity do
       commodity2.children.map(&:pk).should include commodity3.pk
     end
   end
+
+  describe '#ancestors' do
+    describe 'comparing indent numbers' do
+      let!(:commodity) { create :commodity, :with_indent, :with_description,
+                                            indents: 7,
+                                            goods_nomenclature_item_id: '2204219711',
+                                            producline_suffix: '80',
+                                            validity_start_date: Date.new(2010,1,1) }
+
+      let!(:ancestor_commodity) { create :commodity, :with_description,
+                                    goods_nomenclature_item_id: '2204218900',
+                                    producline_suffix: '80',
+                                    validity_start_date: Date.new(1995,1,1) }
+      let!(:indent1) { create(:goods_nomenclature_indent,
+                                goods_nomenclature_sid: ancestor_commodity.goods_nomenclature_sid,
+                                goods_nomenclature_item_id: ancestor_commodity.goods_nomenclature_item_id,
+                                number_indents: 7,
+                                validity_start_date: Date.new(2010,1,1))  }
+      let!(:indent2) { create(:goods_nomenclature_indent,
+                                number_indents: 5,
+                                goods_nomenclature_sid: ancestor_commodity.goods_nomenclature_sid,
+                                goods_nomenclature_item_id: ancestor_commodity.goods_nomenclature_item_id,
+                                validity_start_date: Date.new(1995,1,1))  }
+
+      it 'does not pick ancestor_commodity as ancestor (indent number is not lower (same level))' do
+        commodity.ancestors.should be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
This change is a fix for https://www.pivotaltracker.com/story/show/52133375

We had one too many commodites in the tree on the commodity show page. The reason behind a bug is mainly how MySQL order and group by works (http://blog.chomperstomp.com/how-to-order-by-before-group-by-with-mysql/), i.e. they should happen in separate queries.
