### PR TITLE
Increase decimal size on QuotaBalanceEvents fields

### DIFF
--- a/db/migrate/20130801074451_increase_quota_balance_events_precision.rb
+++ b/db/migrate/20130801074451_increase_quota_balance_events_precision.rb
@@ -1,0 +1,17 @@
+Sequel.migration do
+  up do
+    alter_table :quota_balance_events_oplog do
+      set_column_type :old_balance, BigDecimal, size: [15,3]
+      set_column_type :new_balance, BigDecimal, size: [15,3]
+      set_column_type :imported_amount, BigDecimal, size: [15,3]
+    end
+  end
+
+  down do
+    alter_table :quota_balance_events_oplog do
+      set_column_type :old_balance, BigDecimal, size: [10,3]
+      set_column_type :new_balance, BigDecimal, size: [10,3]
+      set_column_type :imported_amount, BigDecimal, size: [10,3]
+    end
+  end
+end


### PR DESCRIPTION
We lost somes values during import because they were bigger than specified decimal size.

`quota_balance_events_oplog` contains only insert operations and these only come from Taric. So we just need to reimport quota balance events entries to fix this. I uploaded a snapshot called `quota_balance_events_fix.sql.bz2` which contans just the relevant entries for this table (only INSERTs).

How to apply the fix:
1. Make a backup of current quota_balance_events_table
   
   ```
   mysqldump --no-create-info <db_name> quota_balance_events_oplog > quota_balance_events_backup.sql
   ```
2. Deploy migration.
3. Truncate the table. In MySQL prompt issue:
   
   ```
   TRUNCATE quota_balance_events_oplog;
   ```
4. Import updated balance events entries:
   
   ```
   mysql <db_name> < quota_balance_events_fix.sql
   ```
5. Rollback database updates to safe date:
   
   ```
   DATE=2013-07-30 bundle rake tariff:sync:rollback
   ```
   
   Why is this needed? I created `quota_balance_events_fix.sql` on 1st of August and the last Taric update that I have is for 31st of July. So if this update is going to be applied on say 10th of August we will loose quota balance events entries between 31st and 10th of August by TRUNCATING the table. So we have to rollback to a safe date (30th of July) and reapply everything again.
6. Apply the updates again (or leave this to the cron job):
   
   ```
   bundle exec rake tariff:sync:apply
   ```

**How do we know it works?**

Check order number 092816 in https://www.gov.uk/trade-tariff/commodities/3912110020#import it should not say '9999999.999' for balance. Should say 46297530.0 instead (might change with further updates after 31st, but should be something sensible, not many nines).
