### PR TITLE
Add operation_date to national measure inserts

### DIFF
--- a/lib/chief_transformer/candidate_measure/candidate_associations.rb
+++ b/lib/chief_transformer/candidate_measure/candidate_associations.rb
@@ -40,9 +40,11 @@ class ChiefTransformer
           if records.is_a?(Array)
             records.each do |record|
               record.measure_sid = measure.measure_sid if record.respond_to?(:measure_sid=)
+              record.operation_date = measure.operation_date
             end
           else
             records.measure_sid = measure.measure_sid if records.respond_to?(:measure_sid=)
+            record.operation_date = measure.operation_date
           end
         end
       end

--- a/lib/chief_transformer/operations/mfcm_operation.rb
+++ b/lib/chief_transformer/operations/mfcm_operation.rb
@@ -11,12 +11,14 @@ class ChiefTransformer
                 CandidateMeasure.new(mfcm: record,
                                      tame: record.tame,
                                      tamf: tamf,
-                                     operation: :insert)
+                                     operation: :create,
+                                     operation_date: mfcm.operation_date)
               }
             else
               [CandidateMeasure.new(mfcm: record,
                                     tame: record.tame,
-                                    operation: :insert)]
+                                    operation: :create,
+                                    operation_date: mfcm.operation_date)]
             end
           end
         ].flatten.compact)

--- a/spec/integration/chief_transformer/operations/mfcm_insert_spec.rb
+++ b/spec/integration/chief_transformer/operations/mfcm_insert_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper'
+
+describe ChiefTransformer::Processor::MfcmInsert do
+  let(:sample_operation_date) { Date.new(2013,8,5) }
+
+  before(:all) {
+    preload_standing_data
+  }
+
+  after(:all)  { clear_standing_data }
+
+  describe '#process' do
+    context 'mfcm has associated tame' do
+      context 'tame has associated tamfs' do
+        let(:chief_update) {
+          create :chief_update, :applied, issue_date: sample_operation_date
+        }
+
+        let!(:measure_type_coe) { create :measure_type, measure_type_id: 'COE', validity_start_date: Date.new(1972,1,1) }
+
+        let!(:iq) { create(:geographical_area, geographical_area_id: "IQ", geographical_area_sid: -2, validity_start_date: DateTime.parse("1975-07-18 00:00:00")) }
+
+        let!(:mfcm) { create(:mfcm, :with_goods_nomenclature, :prohibition, amend_indicator: "I", fe_tsmp: DateTime.parse("2006-07-24 08:45:00"), msrgp_code: "HO", msr_type: "CON", tar_msr_no: "12113000", cmdty_code: "1211300000", origin: chief_update.filename) }
+        let!(:tame) { create(:tame, :prohibition, amend_indicator: "I", fe_tsmp: DateTime.parse("2006-07-24 08:45:00"), msrgp_code: "HO", msr_type: "CON", tar_msr_no: "12113000", origin: chief_update.filename) }
+        let!(:tamf) { create(:tamf, :prohibition, amend_indicator: "I", fe_tsmp: DateTime.parse("2006-07-24 08:45:00"), msrgp_code: "HO", msr_type: "CON", tar_msr_no: "12113000", cntry_orig: "IQ", origin: chief_update.filename) }
+
+        let!(:geographical_area) { create :geographical_area, :fifteen_years, :erga_omnes, geographical_area_sid: 400 }
+
+        before {
+          ChiefTransformer::Processor::MfcmInsert.new(mfcm).process
+        }
+
+        it 'creates excise measure for 0101010100' do
+          expect(
+            Measure::Operation.where(
+              goods_nomenclature_item_id: '1211300000',
+              national: true,
+              measure_type_id: 'COE',
+              operation: 'C',
+              operation_date: sample_operation_date
+            ).one?
+          ).to be_true
+        end
+
+        it 'creates Measure component for P&R measure' do
+          measure = Measure.national.first
+
+          expect(
+            MeasureCondition::Operation.where(
+              measure_sid: measure.measure_sid,
+              operation: 'C',
+              operation_date: sample_operation_date
+            ).count
+          ).to eq 3
+        end
+      end
+
+      context 'tame has no associated tamfs' do
+        let(:chief_update) {
+          create :chief_update, :applied, issue_date: sample_operation_date
+        }
+
+        let!(:mfcm) { create(:mfcm, :with_goods_nomenclature,
+                                    amend_indicator: "I",
+                                    fe_tsmp: DateTime.parse("2007-11-15 11:00:00"),
+                                    msrgp_code: "VT",
+                                    msr_type: "S",
+                                    tty_code: "813",
+                                    cmdty_code: "0101010100",
+                                    origin: chief_update.filename) }
+
+        let!(:tame) { create(:tame, amend_indicator: "I",
+                                    fe_tsmp: DateTime.parse("2007-11-15 11:00:00"),
+                                    msrgp_code: "VT",
+                                    msr_type: "S",
+                                    tty_code: "813",
+                                    adval_rate: 15.000,
+                                    origin: chief_update.filename) }
+
+        let!(:geographical_area) { create :geographical_area, :fifteen_years, :erga_omnes }
+
+        before {
+          ChiefTransformer::Processor::MfcmInsert.new(mfcm).process
+        }
+
+        it 'creates VAT Standard Measure for 0101010100' do
+          expect(
+            Measure::Operation.where(
+              goods_nomenclature_item_id: '0101010100',
+              national: true,
+              measure_type_id: 'VTS',
+              operation: 'C',
+              operation_date: sample_operation_date
+            ).one?
+          ).to be_true
+        end
+
+        it 'creates Measure component with duty rate of 15 for the VAT Measure' do
+          expect(
+            MeasureComponent::Operation.where(
+              duty_amount: 15.0,
+              operation: 'C',
+              operation_date: sample_operation_date
+            ).one?
+          ).to be_true
+        end
+
+        it 'create Footnote association for the VAT measure' do
+          measure = Measure.national.first
+
+          expect(
+            FootnoteAssociationMeasure::Operation.where(
+              measure_sid: measure.measure_sid,
+              operation: 'C',
+              operation_date: sample_operation_date
+            ).one?
+          ).to be_true
+        end
+      end
+    end
+
+    context 'MFCM has no associated TAMEs' do
+      let(:chief_update) {
+        create :chief_update, :applied, issue_date: sample_operation_date
+      }
+
+      let!(:mfcm) { create(:mfcm, :with_goods_nomenclature, :prohibition, amend_indicator: "I", fe_tsmp: DateTime.parse("2006-07-24 08:45:00"), msrgp_code: "HO", msr_type: "CON", tar_msr_no: "12113000", cmdty_code: "1211300000", origin: chief_update.filename) }
+
+      before {
+        ChiefTransformer::Processor::MfcmInsert.new(mfcm).process
+      }
+
+      specify 'no measures get created' do
+        expect(Measure.count).to eq 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
Affects Measures and measure associations like MeasureCondition, MeasureComponent, MeasureExcludedGeographicalArea and FootnoteAssociationMeasure.

This change is for https://www.pivotaltracker.com/story/show/54514322.

Adds lower level specs for one of CHIEF update operations.
