### PR TITLE
Disable national measure check task

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -3,8 +3,3 @@ set :output, { error: 'log/cron.error.log', standard: 'log/cron.log'}
 every 1.hour do
   rake "tariff:sync:apply"
 end
-
-every 1.day, at: '10pm' do
-  rake "tariff:support:clean_national_measures"
-end
-

--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -164,30 +164,8 @@ namespace :tariff do
   end
 
   namespace :support do
-    # Traverse national measures and remove the ones that are not valid
-    # Used when Mesure conformance validations are extended to remove the ones
-    # that do not comply.
-    desc "Validate and remove invalid national measures"
-    task clean_national_measures: :environment do
-      Measure.national.each_page(1000) do |measure_batch|
-        Sequel::Model.db.transaction do
-          measure_batch.each do |measure|
-            # Adjust measure validity date span
-            if measure.goods_nomenclature.validity_end_date.present? &&
-                measure.validity_end_date.present? &&
-                measure.validity_end_date > measure.goods_nomenclature.validity_end_date
-              measure.validity_end_date = measure.goods_nomenclature.validity_end_date
-              measure.save(validate: false)
-            end
+    desc 'Fix CHIEF initial seed last effective dates'
 
-            # Destroy measure if fails other validations
-            measure.destroy unless measure.valid?
-          end
-        end
-      end
-    end
-
-    desc 'fix chief'
     task fix_chief: :environment do
       Chief::Tame.unprocessed
                  .distinct(:msrgp_code, :msr_type, :tty_code)


### PR DESCRIPTION
I can't find the exact story, but it was decided to report on invalid national Measures instead of deleting them. That is why we sometimes receive Tariff update emails with conformance errors and can investigate what is happening.

I don't think this task did anything destructive to production (or any other environment) since we moved to point database structure and all Model-level validations were rewritten to use our own conformance validator. So `measure.valid?` was always true.
