### PR TITLE
Fix the association between measure conditions and certificate

### DIFF
--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -14,8 +14,8 @@ class MeasureCondition < Sequel::Model
     ds.with_actual(MeasureAction)
   end
 
-  one_to_one :certificate, key: :certificate_code,
-                           primary_key: :certificate_code do |ds|
+  one_to_one :certificate, key: [:certificate_type_code, :certificate_code],
+                           primary_key: [:certificate_type_code, :certificate_code] do |ds|
     ds.with_actual(Certificate)
   end
 


### PR DESCRIPTION
It should use both the certificate type and the code as the key.

There are cases where the codes are the same (for UK certificates) but the type differs

Fixes: https://www.pivotaltracker.com/story/show/55703024
