### PR TITLE
55703384 fix missing duties

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -16,6 +16,7 @@ class Commodity < GoodsNomenclature
   one_to_one :heading, dataset: -> {
     actual_or_relevant(Heading)
            .filter("goods_nomenclatures.goods_nomenclature_item_id LIKE ?", heading_id)
+           .filter(producline_suffix: 80)
   }
 
   one_to_one :chapter, dataset: -> {

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -39,6 +39,31 @@ describe Commodity do
           }
         end
       end
+
+      context 'heading with sub-headings' do
+        # Example from real world scenario
+        # https://www.pivotaltracker.com/story/show/55703384
+
+        let!(:sub_heading) { create :heading, goods_nomenclature_item_id: '6308000000',
+                                              goods_nomenclature_sid: 43837,
+                                              producline_suffix: '10',
+                                              validity_start_date: Date.new(1972,1,1) }
+        let!(:heading) { create :heading, goods_nomenclature_item_id: '6308000000',
+                                              goods_nomenclature_sid: 43838,
+                                              producline_suffix: '80',
+                                              validity_start_date: Date.new(1972,1,1) }
+        let!(:commodity) { create :commodity, :with_indent,
+                                              :with_description,
+                                              indents: 1,
+                                              goods_nomenclature_sid: 91335,
+                                              goods_nomenclature_item_id: '6308000015',
+                                              producline_suffix: '80',
+                                              validity_start_date: Date.new(2009,7,1) }
+
+        it 'correctly identifies heading' do
+          expect(commodity.heading).to eq heading
+        end
+      end
     end
 
     describe 'chapter' do


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/55703384

Real heading have `producline_suffix` of 80 and have associated measures. Wrapping headings like `||. Sets` in https://www.gov.uk/trade-tariff/chapters/63?country=&day=9&month=9&year=2013 have `producline_suffix` of 10 and do not have associated measures. We were including the ones with 10 in our measure fetching code and therefore some measure were missing. So now Commodity -> Heading association explicitly requires `producline_suffix` of 80.
