### PR TITLE
Use SSLV3 for HMRC update server access

### DIFF
--- a/lib/tariff_synchronizer/file_service.rb
+++ b/lib/tariff_synchronizer/file_service.rb
@@ -59,6 +59,8 @@ module TariffSynchronizer
       def send_request(url)
         begin
           crawler = Curl::Easy.new(url)
+          crawler.use_ssl = 3
+          crawler.ssl_version = 3
           crawler.ssl_verify_peer = false
           crawler.ssl_verify_host = false
           crawler.http_auth_types = :basic
@@ -67,6 +69,7 @@ module TariffSynchronizer
           crawler.perform
         rescue Curl::Err::HostResolutionError,
                Curl::Err::ConnectionFailedError,
+               Curl::Err::SSLConnectError,
                Curl::Err::PartialFileError => exception
           # NOTE could be a glitch in curb because it throws HostResolutionError
           # occasionally without any reason.


### PR DESCRIPTION
Not sure if this happened just today on HMRC end or my OSX Mavericks update is to blame, but I cannot access update server any longer with I leave SSL version unset. This change sorts it out.

Does not seem to affect development VM (OSX specific?), works with or without this change.
