### PR TITLE
Fix task call for importing search synonyms

### DIFF
--- a/lib/tasks/tariff.rake
+++ b/lib/tasks/tariff.rake
@@ -63,7 +63,7 @@ namespace :tariff do
   namespace :install do
     desc "Load Green Page (SearchReference) entities from reference file"
     task green_pages: :environment do
-      GreenPages.reload
+      ImportSearchReferences.reload
     end
 
     namespace :taric do


### PR DESCRIPTION
This should have gone in with https://github.com/alphagov/trade-tariff-backend/pull/109

There is no `GreenPages` class any more.
