### PR TITLE
Tire models are paginateable

### DIFF
--- a/lib/sequel/plugins/tire.rb
+++ b/lib/sequel/plugins/tire.rb
@@ -19,6 +19,12 @@ module Sequel
         end
       end
 
+      module ClassMethods
+        def paginate(*args)
+          dataset.paginate(*args)
+        end
+      end
+
       module InstanceMethods
         def destroyed?
           @destroyed || false

--- a/spec/models/goods_nomenclature_spec.rb
+++ b/spec/models/goods_nomenclature_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe GoodsNomenclature do
+  it_behaves_like 'Tire indexable model'
+
   describe 'associations' do
     describe 'goods nomenclature indent' do
       context 'fetching with absolute date' do

--- a/spec/models/search_reference_spec.rb
+++ b/spec/models/search_reference_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe SearchReference do
+  it_behaves_like 'Tire indexable model'
+
   describe '#referenced_entity' do
     context "matching heading regexp" do
       let(:heading) { create :heading, goods_nomenclature_item_id: "1212000000" }

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Section do
+  it_behaves_like 'Tire indexable model'
+
   describe 'associations' do
     describe 'chapters' do
       it 'does not include HiddenGoodsNomenclatures' do

--- a/spec/support/shared_examples/tire_indexable_model_examples.rb
+++ b/spec/support/shared_examples/tire_indexable_model_examples.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+shared_examples_for 'Tire indexable model' do
+  describe '.paginate' do
+    it 'can be paginated' do
+      expect(described_class).to respond_to(:paginate)
+    end
+
+    it 'delegates pagination to dataset' do
+      allow(described_class).to receive(:paginate).and_call_original
+
+      described_class.paginate(page: 1, per_page: 50)
+    end
+  end
+end


### PR DESCRIPTION
This change does not have a story, this is more of an emergency fix because Headings, Chapters, Commodities and search synonyms are not being indexed with cron job at the moment.

Sequel 4.0.0 moved Model.paginate to Model.dataset.paginate. We missed deprecation warning or there was none.
