### PR TITLE
Fix Measure change serialization

### DIFF
--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -27,6 +27,10 @@ class MeasureType < Sequel::Model
     end
   end
 
+  def id
+    measure_type_id
+  end
+
   def third_country?
     measure_type_id == THIRD_COUNTRY
   end

--- a/app/views/api/v1/changes/_measure.json.rabl
+++ b/app/views/api/v1/changes/_measure.json.rabl
@@ -11,10 +11,9 @@ child(geographical_area: :geographical_area) do
   }
 end
 
-node(:measure_type_description) { |obj|
+node(:measure_type) { |measure|
   {
     id: measure.measure_type.id,
     description: measure.measure_type.description
-
   }
 }

--- a/spec/controllers/api/v1/chapters_controller_spec.rb
+++ b/spec/controllers/api/v1/chapters_controller_spec.rb
@@ -67,9 +67,27 @@ describe Api::V1::ChaptersController, "GET #changes" do
 
   let(:chapter) { create :chapter, :with_section, :with_note,
                                    operation_date: Date.today }
+  let(:heading) { create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}20000000" }
+  let!(:measure) {
+    create :measure,
+      :with_measure_type,
+      goods_nomenclature: heading,
+      goods_nomenclature_sid: heading.goods_nomenclature_sid,
+      goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+      operation_date: Date.today
+  }
 
   let(:pattern) {
     [
+      {
+        oid: Integer,
+        model_name: "Measure",
+        record: {
+          measure_type: {
+            description: measure.measure_type.description
+          }.ignore_extra_keys!
+        }.ignore_extra_keys!
+      }.ignore_extra_keys!,
       {
         oid: Integer,
         model_name: "Chapter",

--- a/spec/factories/geographical_area_factory.rb
+++ b/spec/factories/geographical_area_factory.rb
@@ -20,14 +20,16 @@ FactoryGirl.define do
       geographical_code { "0" }
     end
 
+    after(:build) { |geographical_area, evaluator|
+      FactoryGirl.create(:geographical_area_description, :with_period,
+                                                         geographical_area_id: geographical_area.geographical_area_id,
+                                                         geographical_area_sid: geographical_area.geographical_area_sid,
+                                                         valid_at: geographical_area.validity_start_date,
+                                                         valid_to: geographical_area.validity_end_date)
+    }
+
     trait :with_description do
-      after(:create) { |geographical_area, evaluator|
-        FactoryGirl.create(:geographical_area_description, :with_period,
-                                                           geographical_area_id: geographical_area.geographical_area_id,
-                                                           geographical_area_sid: geographical_area.geographical_area_sid,
-                                                           valid_at: geographical_area.validity_start_date,
-                                                           valid_to: geographical_area.validity_end_date)
-      }
+      # noop
     end
   end
 

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -107,6 +107,10 @@ FactoryGirl.define do
   end
 
   factory :measure_type do
+    ignore do
+      measure_type_description { Forgery(:basic).text }
+    end
+
     measure_type_id        { generate(:measure_type_id) }
     measure_type_series_id { Forgery(:basic).text(exactly: 1) }
     validity_start_date    { Date.today.ago(3.years) }
@@ -124,6 +128,14 @@ FactoryGirl.define do
 
     after(:build) { |measure_type, evaluator|
       FactoryGirl.create(:measure_type_series, measure_type_series_id: measure_type.measure_type_series_id)
+    }
+
+    after(:build) { |measure_type, evaluator|
+      FactoryGirl.create(
+        :measure_type_description,
+        measure_type_id: measure_type.measure_type_id,
+        description: evaluator.measure_type_description
+      )
     }
   end
 

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -888,11 +888,11 @@ describe Measure do
   end
 
   describe '#national_measurement_units_for' do
-    let(:measure_type) { create :measure_type, measure_type_id: measure_type_description.measure_type_id, measure_type_description: measure_type_description }
+    let(:measure_type) { create :measure_type, measure_type_description: measure_type_description }
     let(:measure)   { create :measure, measure_type_id: measure_type.measure_type_id }
 
     context 'measure is excise' do
-      let(:measure_type_description) { create :measure_type_description, description: 'EXCISE 111' }
+      let(:measure_type_description) { 'EXCISE 111' }
 
       context 'declarable is passed in' do
         let(:commodity) { create :commodity }


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/60242196

As in commodities#show request Measure should expose the following structure:

``` json
{
  measure_type: {
    id: '',
    description: ''
  }
}
```

Instead of having `measure_type_description key`.

This prevent certain goods code changes from working.

Fixed/enhanced a few specs as well.
