### PR TITLE
Fix change feed serve issues

### DIFF
--- a/app/controllers/api/v1/chapters_controller.rb
+++ b/app/controllers/api/v1/chapters_controller.rb
@@ -21,7 +21,9 @@ module Api
       end
 
       def changes
-        @changes = @chapter.changes
+        @changes = ChangeLog.new(@chapter.changes.where { |o|
+          o.operation_date <= actual_date
+        })
 
         render 'api/v1/changes/changes'
       end

--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -35,7 +35,9 @@ module Api
       end
 
       def changes
-        @changes = @commodity.changes
+        @changes = ChangeLog.new(@commodity.changes.where { |o|
+          o.operation_date <= actual_date
+        })
 
         render 'api/v1/changes/changes'
       end

--- a/app/controllers/api/v1/headings_controller.rb
+++ b/app/controllers/api/v1/headings_controller.rb
@@ -44,7 +44,9 @@ module Api
       end
 
       def changes
-        @changes = @heading.changes
+        @changes = ChangeLog.new(@heading.changes.where { |o|
+          o.operation_date <= actual_date
+        })
 
         render 'api/v1/changes/changes'
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,8 +40,15 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def actual_date
+    Date.parse(params[:as_of].to_s)
+
+    rescue ArgumentError # empty as_of param means today
+      Date.today
+  end
+
   def configure_time_machine
-    TimeMachine.at(params[:as_of]) do
+    TimeMachine.at(actual_date) do
       yield
     end
   end

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -15,8 +15,14 @@ class Change
     @operation_record ||= operation_class.find(oid: oid)
   end
 
+  # Initialize with call to bypass restricted column check
+  # we have no intention of modying these records therefore
+  # they are frozen after initialization
+  #
+  # records for modification should be fetched directly from
+  # Model classes, not through Model::Operation#record
   def record
-    operation_record.record
+    operation_record.record_class.call(operation_record.values).freeze
   end
 
   def model_name

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -101,28 +101,25 @@ class Chapter < GoodsNomenclature
   end
 
   def changes(depth = 1)
-    ChangeLog.new(
-      operation_klass.select(
-        Sequel.as('Chapter', :model),
-        :oid,
-        :operation_date,
-        :operation,
-        Sequel.as(depth, :depth)
-      ).where(pk_hash)
-       .union(Heading.changes_for(depth + 1, ["goods_nomenclature_item_id LIKE ? AND goods_nomenclature_item_id NOT LIKE ?", relevant_headings, '__00______']))
-       .union(Commodity.changes_for(depth + 1, ["goods_nomenclature_item_id LIKE ? AND goods_nomenclature_item_id NOT LIKE ?", relevant_commodities, '____000000']))
-       .union(Measure.changes_for(depth +1, ["goods_nomenclature_item_id LIKE ?", relevant_commodities]))
-       .from_self
-       .where(Sequel.~(operation_date: nil))
-       .tap! { |criteria|
-         # if Chapter did not come from initial seed, filter by its
-         # create/update date
-         criteria.where{ |o| o.>=(:operation_date, operation_date) } unless operation_date.blank?
-        }
-       .limit(TradeTariffBackend.change_count)
-       .order(Sequel.function(:isnull, :operation_date), Sequel.desc(:operation_date), Sequel.desc(:depth))
-       .all
-    )
+    operation_klass.select(
+      Sequel.as('Chapter', :model),
+      :oid,
+      :operation_date,
+      :operation,
+      Sequel.as(depth, :depth)
+    ).where(pk_hash)
+     .union(Heading.changes_for(depth + 1, ["goods_nomenclature_item_id LIKE ? AND goods_nomenclature_item_id NOT LIKE ?", relevant_headings, '__00______']))
+     .union(Commodity.changes_for(depth + 1, ["goods_nomenclature_item_id LIKE ? AND goods_nomenclature_item_id NOT LIKE ?", relevant_commodities, '____000000']))
+     .union(Measure.changes_for(depth +1, ["goods_nomenclature_item_id LIKE ?", relevant_commodities]))
+     .from_self
+     .where(Sequel.~(operation_date: nil))
+     .tap! { |criteria|
+       # if Chapter did not come from initial seed, filter by its
+       # create/update date
+       criteria.where{ |o| o.>=(:operation_date, operation_date) } unless operation_date.blank?
+      }
+     .limit(TradeTariffBackend.change_count)
+     .order(Sequel.function(:isnull, :operation_date), Sequel.desc(:operation_date), Sequel.desc(:depth))
   end
 
   private

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -193,25 +193,22 @@ class Commodity < GoodsNomenclature
   end
 
   def changes(depth = 1)
-    ChangeLog.new(
-      operation_klass.select(
-        Sequel.as('GoodsNomenclature', :model),
-        :oid,
-        :operation_date,
-        :operation,
-        Sequel.as(depth, :depth)
-      ).where(pk_hash)
-       .union(Measure.changes_for(depth + 1, measures_oplog__measure_sid: measures.map(&:measure_sid)))
-       .from_self
-       .where(Sequel.~(operation_date: nil))
-       .tap! { |criteria|
-         # if Commodity did not come from initial seed, filter by its
-         # create/update date
-         criteria.where{ |o| o.>=(:operation_date, operation_date) } unless operation_date.blank?
-        }
-       .limit(TradeTariffBackend.change_count)
-       .order(Sequel.function(:isnull, :operation_date), Sequel.desc(:operation_date), Sequel.desc(:depth))
-       .all
-     )
+    operation_klass.select(
+      Sequel.as('GoodsNomenclature', :model),
+      :oid,
+      :operation_date,
+      :operation,
+      Sequel.as(depth, :depth)
+    ).where(pk_hash)
+     .union(Measure.changes_for(depth + 1, Sequel.qualify(:measures_oplog, :goods_nomenclature_item_id) => goods_nomenclature_item_id))
+     .from_self
+     .where(Sequel.~(operation_date: nil))
+     .tap! { |criteria|
+       # if Commodity did not come from initial seed, filter by its
+       # create/update date
+       criteria.where{ |o| o.>=(:operation_date, operation_date) } unless operation_date.blank?
+      }
+     .limit(TradeTariffBackend.change_count)
+     .order(Sequel.function(:isnull, :operation_date), Sequel.desc(:operation_date), Sequel.desc(:depth))
   end
 end

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -128,27 +128,24 @@ class Heading < GoodsNomenclature
   end
 
   def changes(depth = 1)
-    ChangeLog.new(
-      operation_klass.select(
-        Sequel.as('Heading', :model),
-        :oid,
-        :operation_date,
-        :operation,
-        Sequel.as(depth, :depth)
-      ).where(pk_hash)
-       .union(Commodity.changes_for(depth + 1, ["goods_nomenclature_item_id LIKE ? AND goods_nomenclature_item_id NOT LIKE ?", relevant_commodities, '____000000']))
-       .union(Measure.changes_for(depth +1, ["goods_nomenclature_item_id LIKE ?", relevant_commodities]))
-       .from_self
-       .where(Sequel.~(operation_date: nil))
-       .tap! { |criteria|
-         # if Heading did not come from initial seed, filter by its
-         # create/update date
-         criteria.where{ |o| o.>=(:operation_date, operation_date) } unless operation_date.blank?
-        }
-       .limit(TradeTariffBackend.change_count)
-       .order(Sequel.function(:isnull, :operation_date), Sequel.desc(:operation_date), Sequel.desc(:depth))
-       .all
-    )
+    operation_klass.select(
+      Sequel.as('Heading', :model),
+      :oid,
+      :operation_date,
+      :operation,
+      Sequel.as(depth, :depth)
+    ).where(pk_hash)
+     .union(Commodity.changes_for(depth + 1, ["goods_nomenclature_item_id LIKE ? AND goods_nomenclature_item_id NOT LIKE ?", relevant_commodities, '____000000']))
+     .union(Measure.changes_for(depth +1, ["goods_nomenclature_item_id LIKE ?", relevant_commodities]))
+     .from_self
+     .where(Sequel.~(operation_date: nil))
+     .tap! { |criteria|
+       # if Heading did not come from initial seed, filter by its
+       # create/update date
+       criteria.where { |o| o.>=(:operation_date, operation_date) } unless operation_date.blank?
+      }
+     .limit(TradeTariffBackend.change_count)
+     .order(Sequel.function(:isnull, :operation_date), Sequel.desc(:operation_date), Sequel.desc(:depth))
   end
 
   def self.changes_for(depth = 0, conditions = {})

--- a/app/models/null_commodity.rb
+++ b/app/models/null_commodity.rb
@@ -1,0 +1,2 @@
+class NullCommodity < NullGoodsNomenclature
+end

--- a/lib/sequel/plugins/oplog.rb
+++ b/lib/sequel/plugins/oplog.rb
@@ -8,7 +8,12 @@ module Sequel
 
         # Define ModelClass::Operation
         # e.g. Measure::Operation for measure oplog table
-        operation_class = Class.new(Sequel::Model(:"#{model.table_name}_oplog"))
+        operation_class = Class.new(Sequel::Model(:"#{model.table_name}_oplog")) do
+          def record_class
+            self.class.to_s.chomp("::Operation").constantize
+          end
+        end
+
         operation_class.one_to_one(
           :record,
           key: model_primary_key,

--- a/spec/controllers/api/v1/chapters_controller_spec.rb
+++ b/spec/controllers/api/v1/chapters_controller_spec.rb
@@ -68,47 +68,121 @@ end
 describe Api::V1::ChaptersController, "GET #changes" do
   render_views
 
-  let(:chapter) { create :chapter, :with_section, :with_note,
-                                   operation_date: Date.today }
-  let(:heading) { create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}20000000" }
-  let!(:measure) {
-    create :measure,
-      :with_measure_type,
-      goods_nomenclature: heading,
-      goods_nomenclature_sid: heading.goods_nomenclature_sid,
-      goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
-      operation_date: Date.today
-  }
+  context 'changes happened after chapter creation' do
+    let(:chapter) { create :chapter, :with_section, :with_note,
+                                     operation_date: Date.today }
 
-  let(:pattern) {
-    [
-      {
-        oid: Integer,
-        model_name: "Measure",
-        record: {
-          measure_type: {
-            description: measure.measure_type.description
+    let(:heading) { create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}20000000" }
+    let!(:measure) {
+      create :measure,
+        :with_measure_type,
+        goods_nomenclature: heading,
+        goods_nomenclature_sid: heading.goods_nomenclature_sid,
+        goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+        operation_date: Date.today
+    }
+
+    let(:pattern) {
+      [
+        {
+          oid: Integer,
+          model_name: "Measure",
+          record: {
+            measure_type: {
+              description: measure.measure_type.description
+            }.ignore_extra_keys!
           }.ignore_extra_keys!
-        }.ignore_extra_keys!
-      }.ignore_extra_keys!,
-      {
-        oid: Integer,
-        model_name: "Chapter",
-        operation: String,
-        operation_date: String,
-        record: {
-          description: String,
-          goods_nomenclature_item_id: String,
-          validity_start_date: String,
-          validity_end_date: nil
+        }.ignore_extra_keys!,
+        {
+          oid: Integer,
+          model_name: "Chapter",
+          operation: String,
+          operation_date: String,
+          record: {
+            description: String,
+            goods_nomenclature_item_id: String,
+            validity_start_date: String,
+            validity_end_date: nil
+          }
         }
-      }
-    ].ignore_extra_values!
-  }
+      ].ignore_extra_values!
+    }
 
-  it 'returns chapter changes' do
-    get :changes, id: chapter, format: :json
+    it 'returns chapter changes' do
+      get :changes, id: chapter, format: :json
 
-    response.body.should match_json_expression pattern
+      response.body.should match_json_expression pattern
+    end
+  end
+
+  context 'changes happened before requested date' do
+    let(:chapter) { create :chapter, :with_section, :with_note,
+                                     operation_date: Date.today }
+    let(:heading) { create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}20000000" }
+    let!(:measure) {
+      create :measure,
+        :with_measure_type,
+        goods_nomenclature: heading,
+        goods_nomenclature_sid: heading.goods_nomenclature_sid,
+        goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+        operation_date: Date.today
+    }
+
+    it 'does not include change records' do
+      get :changes, id: chapter, as_of: Date.yesterday, format: :json
+
+      response.body.should match_json_expression []
+    end
+  end
+
+  context 'changes include deleted record' do
+    let(:chapter) { create :chapter, :with_section, :with_note,
+                                     operation_date: Date.today }
+
+    let(:heading) { create :heading, goods_nomenclature_item_id: "#{chapter.goods_nomenclature_item_id.first(2)}20000000" }
+    let!(:measure) {
+      create :measure,
+        :with_measure_type,
+        goods_nomenclature: heading,
+        goods_nomenclature_sid: heading.goods_nomenclature_sid,
+        goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+        operation_date: Date.today
+    }
+
+    let(:pattern) {
+      [
+        {
+          oid: Integer,
+          model_name: "Measure",
+          operation: "D",
+          record: {
+            goods_nomenclature_item_id: measure.goods_nomenclature_item_id,
+            measure_type: {
+              description: measure.measure_type.description
+            }.ignore_extra_keys!
+          }.ignore_extra_keys!
+        }.ignore_extra_keys!,
+        {
+          oid: Integer,
+          model_name: "Chapter",
+          operation: String,
+          operation_date: String,
+          record: {
+            description: String,
+            goods_nomenclature_item_id: String,
+            validity_start_date: String,
+            validity_end_date: nil
+          }
+        }
+      ].ignore_extra_values!
+    }
+
+    before { measure.destroy }
+
+    it 'renders record attributes' do
+      get :changes, id: chapter, format: :json
+
+      response.body.should match_json_expression pattern
+    end
   end
 end

--- a/spec/controllers/api/v1/commodities_controller_spec.rb
+++ b/spec/controllers/api/v1/commodities_controller_spec.rb
@@ -72,33 +72,103 @@ end
 describe Api::V1::CommoditiesController, "GET #changes" do
   render_views
 
-  let!(:commodity) { create :commodity, :with_indent,
-                                        :with_chapter,
-                                        :with_heading,
-                                        :with_description,
-                                        :declarable,
-                                        operation_date: Date.today }
+  context 'changes happened after chapter creation' do
+    let!(:commodity) { create :commodity, :with_indent,
+                                          :with_chapter,
+                                          :with_heading,
+                                          :with_description,
+                                          :declarable,
+                                          operation_date: Date.today }
 
-  let(:pattern) {
-    [
-      {
-        oid: Integer,
-        model_name: "GoodsNomenclature",
-        operation: String,
-        operation_date: String,
-        record: {
-          description: String,
-          goods_nomenclature_item_id: String,
-          validity_start_date: String,
-          validity_end_date: nil
+    let(:pattern) {
+      [
+        {
+          oid: Integer,
+          model_name: "GoodsNomenclature",
+          operation: String,
+          operation_date: String,
+          record: {
+            description: String,
+            goods_nomenclature_item_id: String,
+            validity_start_date: String,
+            validity_end_date: nil
+          }
         }
-      }
-    ].ignore_extra_values!
-  }
+      ].ignore_extra_values!
+    }
 
-  it 'returns commodity changes' do
-    get :changes, id: commodity, format: :json
+    it 'returns commodity changes' do
+      get :changes, id: commodity, format: :json
 
-    response.body.should match_json_expression pattern
+      response.body.should match_json_expression pattern
+    end
+  end
+
+  context 'changes happened before requested date' do
+    let!(:commodity) { create :commodity, :with_indent,
+                                          :with_chapter,
+                                          :with_heading,
+                                          :with_description,
+                                          :declarable,
+                                          operation_date: Date.today }
+
+    it 'does not include change records' do
+      get :changes, id: commodity, as_of: Date.yesterday, format: :json
+
+      response.body.should match_json_expression []
+    end
+  end
+
+  context 'changes include deleted record' do
+    let!(:commodity) { create :commodity, :with_indent,
+                                          :with_chapter,
+                                          :with_heading,
+                                          :with_description,
+                                          :declarable,
+                                          operation_date: Date.today }
+    let!(:measure) {
+      create :measure,
+        :with_measure_type,
+        goods_nomenclature: commodity,
+        goods_nomenclature_sid: commodity.goods_nomenclature_sid,
+        goods_nomenclature_item_id: commodity.goods_nomenclature_item_id,
+        operation_date: Date.today
+    }
+
+    let(:pattern) {
+      [
+        {
+          oid: Integer,
+          model_name: "Measure",
+          operation: "D",
+          record: {
+            goods_nomenclature_item_id: measure.goods_nomenclature_item_id,
+            measure_type: {
+              description: measure.measure_type.description
+            }.ignore_extra_keys!
+          }.ignore_extra_keys!
+        }.ignore_extra_keys!,
+        {
+          oid: Integer,
+          model_name: String,
+          operation: String,
+          operation_date: String,
+          record: {
+            description: String,
+            goods_nomenclature_item_id: String,
+            validity_start_date: String,
+            validity_end_date: nil
+          }
+        }
+      ].ignore_extra_values!
+    }
+
+    before { measure.destroy }
+
+    it 'renders record attributes' do
+      get :changes, id: commodity, format: :json
+
+      response.body.should match_json_expression pattern
+    end
   end
 end

--- a/spec/controllers/api/v1/headings_controller_spec.rb
+++ b/spec/controllers/api/v1/headings_controller_spec.rb
@@ -95,32 +95,99 @@ end
 describe Api::V1::HeadingsController, "GET #changes" do
   render_views
 
-  let(:heading) { create :heading, :non_grouping,
-                                   :non_declarable,
-                                   :with_description,
-                                   :with_chapter,
-                                   operation_date: Date.today }
+  context 'changes happened after chapter creation' do
+    let(:heading) { create :heading, :non_grouping,
+                                     :non_declarable,
+                                     :with_description,
+                                     :with_chapter,
+                                     operation_date: Date.today }
 
-  let(:pattern) {
-    [
-      {
-        oid: Integer,
-        model_name: "Heading",
-        operation: String,
-        operation_date: String,
-        record: {
-          description: String,
-          goods_nomenclature_item_id: String,
-          validity_start_date: String,
-          validity_end_date: nil
+    let(:pattern) {
+      [
+        {
+          oid: Integer,
+          model_name: "Heading",
+          operation: String,
+          operation_date: String,
+          record: {
+            description: String,
+            goods_nomenclature_item_id: String,
+            validity_start_date: String,
+            validity_end_date: nil
+          }
         }
-      }
-    ].ignore_extra_values!
-  }
+      ].ignore_extra_values!
+    }
 
-  it 'returns heading changes' do
-    get :changes, id: heading, format: :json
+    it 'returns heading changes' do
+      get :changes, id: heading, format: :json
 
-    response.body.should match_json_expression pattern
+      response.body.should match_json_expression pattern
+    end
+  end
+
+  context 'changes happened before requested date' do
+    let(:heading) { create :heading, :non_grouping,
+                                     :non_declarable,
+                                     :with_description,
+                                     :with_chapter,
+                                     operation_date: Date.today }
+
+    it 'does not include change records' do
+      get :changes, id: heading, as_of: Date.yesterday, format: :json
+
+      response.body.should match_json_expression []
+    end
+  end
+
+  context 'changes include deleted record' do
+    let(:heading) { create :heading, :non_grouping,
+                                     :non_declarable,
+                                     :with_description,
+                                     :with_chapter,
+                                     operation_date: Date.today }
+    let!(:measure) {
+      create :measure,
+        :with_measure_type,
+        goods_nomenclature: heading,
+        goods_nomenclature_sid: heading.goods_nomenclature_sid,
+        goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
+        operation_date: Date.today
+    }
+    let(:pattern) {
+      [
+        {
+          oid: Integer,
+          model_name: "Measure",
+          operation: "D",
+          record: {
+            goods_nomenclature_item_id: measure.goods_nomenclature_item_id,
+            measure_type: {
+              description: measure.measure_type.description
+            }.ignore_extra_keys!
+          }.ignore_extra_keys!
+        }.ignore_extra_keys!,
+        {
+          oid: Integer,
+          model_name: "Heading",
+          operation: String,
+          operation_date: String,
+          record: {
+            description: String,
+            goods_nomenclature_item_id: String,
+            validity_start_date: String,
+            validity_end_date: nil
+          }
+        }
+      ].ignore_extra_values!
+    }
+
+    before { measure.destroy }
+
+    it 'renders record attributes' do
+      get :changes, id: heading, format: :json
+
+      response.body.should match_json_expression pattern
+    end
   end
 end

--- a/spec/models/change_spec.rb
+++ b/spec/models/change_spec.rb
@@ -19,7 +19,7 @@ describe Change do
 
   describe '#record' do
     it 'returns model associated with change operation' do
-      expect(change.record).to eq measure
+      expect(change.record.pk).to eq measure.pk
     end
   end
 end

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -76,8 +76,8 @@ describe Chapter do
   describe '#changes' do
     let(:chapter) { create :chapter }
 
-    it 'returns instance of ChangeLog' do
-      expect(chapter.changes).to be_kind_of ChangeLog
+    it 'returns Sequel Dataset' do
+      expect(chapter.changes).to be_kind_of Sequel::Dataset
     end
 
     context 'with Chapter changes' do

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -322,8 +322,8 @@ describe Commodity do
   describe '#changes' do
     let(:commodity) { create :commodity }
 
-    it 'returns instance of ChangeLog' do
-      expect(commodity.changes).to be_kind_of ChangeLog
+    it 'returns Sequel Dataset' do
+      expect(commodity.changes).to be_kind_of Sequel::Dataset
     end
 
     context 'with commodity changes' do

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -151,8 +151,8 @@ describe Heading do
   describe '#changes' do
     let(:heading) { create :heading }
 
-    it 'returns instance of ChangeLog' do
-      expect(heading.changes).to be_kind_of ChangeLog
+    it 'returns Sequel Dataset' do
+      expect(heading.changes).to be_kind_of Sequel::Dataset
     end
 
     context 'with Heading changes' do


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/61556230

Fixes several issues: 
- Filters changes by passed actual (as_of) date as we do with other Tariff entities
- Make sure we display change record entries for deleted entities (change on Model::Operation#record)

Depends on frontend change https://github.com/alphagov/trade-tariff-frontend/pull/100
