### PR TITLE
Simplify Measure Condition rendering

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -26,7 +26,7 @@ class Measure < Sequel::Model
                     end
 
   one_to_many :measure_conditions, key: :measure_sid,
-    order: Sequel.asc(:component_sequence_number)
+    order: [Sequel.asc(:condition_code), Sequel.asc(:component_sequence_number)]
 
   one_to_one :geographical_area, key: :geographical_area_sid,
                         primary_key: :geographical_area_sid,

--- a/spec/factories/certificate_factory.rb
+++ b/spec/factories/certificate_factory.rb
@@ -2,6 +2,10 @@ FactoryGirl.define do
   sequence(:certificate_sid) { |n| n}
 
   factory :certificate do
+    ignore do
+      description { Forgery(:basic).text }
+    end
+
     certificate_type_code { Forgery(:basic).text(exactly: 1) }
     certificate_code      { Forgery(:basic).text(exactly: 3) }
     validity_start_date   { Date.today.ago(2.years) }
@@ -39,8 +43,25 @@ FactoryGirl.define do
   end
 
   factory :certificate_type do
+    ignore do
+      description { Forgery(:basic).text }
+    end
+
     certificate_type_code              { Forgery(:basic).text(exactly: 1) }
     validity_start_date                { Date.today.ago(2.years) }
     validity_end_date                  { nil }
+
+    trait :with_description do
+      after(:create) { |certificate_type, evaluator|
+        FactoryGirl.create(:certificate_type_description,
+                           certificate_type_code: certificate_type.certificate_type_code,
+                           description: evaluator.description)
+      }
+    end
+  end
+
+  factory :certificate_type_description do
+    certificate_type_code { Forgery(:basic).text(exactly: 1) }
+    description           { Forgery(:basic).text }
   end
 end

--- a/spec/factories/measurement_unit_factory.rb
+++ b/spec/factories/measurement_unit_factory.rb
@@ -1,12 +1,18 @@
 FactoryGirl.define do
   factory :measurement_unit do
+    ignore do
+      description { Forgery(:basic).text }
+    end
+
     measurement_unit_code { Forgery(:basic).text(exactly: 3) }
     validity_start_date { Date.today.ago(3.years) }
     validity_end_date   { nil }
 
     trait :with_description do
       after(:create) { |measurement_unit, evaluator|
-        FactoryGirl.create :measurement_unit_description, measurement_unit_code: measurement_unit.measurement_unit_code
+        FactoryGirl.create :measurement_unit_description,
+          measurement_unit_code: measurement_unit.measurement_unit_code,
+          description: evaluator.description
       }
     end
   end

--- a/spec/models/measure_condition_spec.rb
+++ b/spec/models/measure_condition_spec.rb
@@ -85,4 +85,65 @@ describe MeasureCondition do
       end
     end
   end
+
+  describe '#requirement' do
+    context 'with document requirement' do
+      let(:certificate_type) {
+        create :certificate_type, :with_description,
+          description: 'FOO'
+      }
+      let(:certificate_description) {
+        create :certificate_description, :with_period,
+          certificate_type_code: certificate_type.certificate_type_code,
+          description: 'BAR'
+      }
+      let(:certificate) {
+        create :certificate,
+          certificate_code: certificate_description.certificate_code,
+          certificate_type_code: certificate_description.certificate_type_code
+      }
+      let(:measure_condition) {
+        create :measure_condition,
+          condition_code: 'L',
+          component_sequence_number: 3,
+          condition_duty_amount: nil,
+          condition_monetary_unit_code: nil,
+          condition_measurement_unit_code: nil,
+          condition_measurement_unit_qualifier_code: nil,
+          certificate_code: certificate.certificate_code,
+          certificate_type_code: certificate.certificate_type_code
+      }
+
+      it 'returns requirement certificate type and description' do
+        expect(measure_condition.requirement).to eq "FOO: BAR"
+      end
+    end
+
+    context 'with duty expression requirement' do
+      let(:monetary_unit) {
+        create :monetary_unit, :with_description,
+          monetary_unit_code: 'FOO'
+      }
+      let(:measurement_unit) {
+        create :measurement_unit, :with_description,
+          description: 'BAR'
+      }
+
+      let(:measure_condition) {
+        create :measure_condition,
+          condition_code: 'L',
+          component_sequence_number: 3,
+          condition_duty_amount: 108.56,
+          condition_monetary_unit_code: monetary_unit.monetary_unit_code,
+          condition_measurement_unit_code: measurement_unit.measurement_unit_code,
+          condition_measurement_unit_qualifier_code: nil,
+          certificate_code: nil,
+          certificate_type_code: nil
+      }
+
+      it 'returns rendered requirement duty expression' do
+        expect(measure_condition.requirement).to eq "108.56 FOO/BAR"
+      end
+    end
+  end
 end

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -173,8 +173,8 @@ describe Measure do
 
       describe 'ordering' do
         let!(:measure)                { create :measure }
-        let!(:measure_condition1)     { create :measure_condition, measure_sid: measure.measure_sid, component_sequence_number: 10 }
-        let!(:measure_condition2)     { create :measure_condition, measure_sid: measure.measure_sid, component_sequence_number: 1 }
+        let!(:measure_condition1)     { create :measure_condition, measure_sid: measure.measure_sid, condition_code: 'L', component_sequence_number: 10 }
+        let!(:measure_condition2)     { create :measure_condition, measure_sid: measure.measure_sid, condition_code: 'A', component_sequence_number: 1 }
 
         it 'loads conditions ordered by component sequence number ascending' do
           expect(measure.measure_conditions.first).to eq measure_condition2


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/61986128

The error was introduced with changes for public API, when formatters were moved to the backend.

We used to present Measure Conditions like the old tariff did. This change alters that and displays them the same way EU TARIC does. It is not a significant change, all information is still there. As a result the code is simpler - less logic involved.

I added more test cases to Tariff Suite: https://github.com/alphagov/trade-tariff-suite/pull/2
