### PR TITLE
Introduce resource links in API responses

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  # Used in generating links in JSON responses
+  #
+  # Trade Tariff Frontend app proxies API requests to the
+  # backend. We need to prefix the link /trade-tariff (which
+  # is an app slug of tariff) so that users would receive
+  # correct links
+  def api_link(relative_link)
+    "/trade-tariff#{relative_link}"
+  end
 end

--- a/app/views/api/v1/chapters/show.json.rabl
+++ b/app/views/api/v1/chapters/show.json.rabl
@@ -22,3 +22,12 @@ node(:headings) do
     partial("api/v1/headings/heading", object: heading)
   end
 end
+
+node(:_response_info) do
+  {
+    links: [
+      { rel: 'self', href: api_link(request.fullpath) },
+      { rel: 'section', href: api_link(api_section_path(@chapter.section)) },
+    ]
+  }
+end

--- a/app/views/api/v1/commodities/show.json.rabl
+++ b/app/views/api/v1/commodities/show.json.rabl
@@ -21,3 +21,14 @@ child(@commodity.ancestors => :ancestors) {
                :formatted_description,
                :description_plain
 }
+
+node(:_response_info) do
+  {
+    links: [
+      { rel: 'self', href: api_link(request.fullpath) },
+      { rel: 'heading', href: api_link(api_heading_path(@commodity.heading)) },
+      { rel: 'chapter', href: api_link(api_chapter_path(@commodity.chapter)) },
+      { rel: 'section', href: api_link(api_section_path(@commodity.section)) }
+    ]
+  }
+end

--- a/app/views/api/v1/headings/show.json.rabl
+++ b/app/views/api/v1/headings/show.json.rabl
@@ -28,3 +28,13 @@ else
     node(:parent_sid) { |commodity| commodity.parent.try(:goods_nomenclature_sid) }
   }
 end
+
+node(:_response_info) do
+  {
+    links: [
+      { rel: 'self', href: api_link(request.fullpath) },
+      { rel: 'chapter', href: api_link(api_chapter_path(@heading.chapter)) },
+      { rel: 'section', href: api_link(api_section_path(@heading.section)) }
+    ]
+  }
+end

--- a/app/views/api/v1/sections/show.json.rabl
+++ b/app/views/api/v1/sections/show.json.rabl
@@ -12,3 +12,12 @@ child(chapters: :chapters) do
 
   node(:chapter_note_id) { |chapter| chapter.chapter_note.try(:id) }
 end
+
+node(:_response_info) do
+  {
+    links: [
+      { rel: 'self', href: api_link(request.fullpath) },
+      { rel: 'sections', href: api_link(api_sections_path) },
+    ]
+  }
+end

--- a/spec/controllers/api/v1/chapters_controller_spec.rb
+++ b/spec/controllers/api/v1/chapters_controller_spec.rb
@@ -13,7 +13,8 @@ describe Api::V1::ChaptersController, "GET #show" do
       headings: Array,
       section: {
         section_note: String
-      }.ignore_extra_keys!
+      }.ignore_extra_keys!,
+      _response_info: Hash
     }.ignore_extra_keys!
   }
 

--- a/spec/controllers/api/v1/commodities_controller_spec.rb
+++ b/spec/controllers/api/v1/commodities_controller_spec.rb
@@ -16,6 +16,7 @@ describe Api::V1::CommoditiesController, "GET #show" do
       section: Hash,
       import_measures: Array,
       export_measures: Array,
+      _response_info: Hash,
     }.ignore_extra_keys!
   }
 

--- a/spec/controllers/api/v1/headings_controller_spec.rb
+++ b/spec/controllers/api/v1/headings_controller_spec.rb
@@ -6,15 +6,19 @@ describe Api::V1::HeadingsController, "GET #show" do
   context 'non-declarable heading' do
     let(:heading) { create :heading, :non_grouping,
                                      :non_declarable,
-                                     :with_description,
-                                     :with_chapter }
+                                     :with_description }
+    let!(:chapter) { create :chapter,
+                     :with_section, :with_description,
+                     goods_nomenclature_item_id: heading.chapter_id
+    }
 
     let(:pattern) {
       {
         goods_nomenclature_item_id: heading.code,
         description: String,
         commodities: Array,
-        chapter: Hash
+        chapter: Hash,
+        _response_info: Hash
       }.ignore_extra_keys!
     }
 
@@ -51,16 +55,20 @@ describe Api::V1::HeadingsController, "GET #show" do
 
   context 'declarable heading' do
     let!(:heading) { create :heading, :with_indent,
-                                      :with_chapter,
                                       :with_description,
                                       :declarable }
+    let!(:chapter) { create :chapter,
+                     :with_section, :with_description,
+                     goods_nomenclature_item_id: heading.chapter_id }
+
     let(:pattern) {
       {
         goods_nomenclature_item_id: heading.goods_nomenclature_item_id,
         description: String,
         chapter: Hash,
         import_measures: Array,
-        export_measures: Array
+        export_measures: Array,
+        _response_info: Hash
       }.ignore_extra_keys!
     }
 

--- a/spec/controllers/api/v1/sections_controller_spec.rb
+++ b/spec/controllers/api/v1/sections_controller_spec.rb
@@ -14,7 +14,8 @@ describe Api::V1::SectionsController, "GET #show" do
       numeral: String,
       chapter_from: String,
       chapter_to: String,
-      chapters: Array
+      chapters: Array,
+      _response_info: Hash
     }
   }
 


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/61656166

As seen in other API server apps (https://github.com/alphagov/gds-api-adapters/blob/062af656878e3aacd492b2ddaec77caed683f4aa/test/list_response_test.rb#L52-L55 https://github.com/alphagov/business-support-api/blob/master/app/views/business_support/search.json.erb) adds `links` Hash to tariff api responses. This enables automatic API traversal if needed.
