### PR TITLE
Add commodity synonym management API endpoint

### DIFF
--- a/app/controllers/api/v1/commodities/search_references_controller.rb
+++ b/app/controllers/api/v1/commodities/search_references_controller.rb
@@ -1,0 +1,38 @@
+module Api
+  module V1
+    module Commodities
+      class SearchReferencesController < Api::V1::SearchReferencesBaseController
+        private
+
+        def search_reference_collection
+          commodity.search_references_dataset
+        end
+
+        def search_reference_resource_association_hash
+          { commodity: commodity }
+        end
+
+        def collection_url
+          [:api, commodity, @search_reference]
+        end
+
+        def commodity
+          @commodity ||= begin
+            commodity = Commodity.actual
+                   .declarable
+                   .by_code(commodity_id)
+                   .take
+
+            raise Sequel::RecordNotFound if commodity.goods_nomenclature_item_id.in?(HiddenGoodsNomenclature.codes)
+
+            commodity
+          end
+        end
+
+        def commodity_id
+          params[:commodity_id]
+        end
+      end
+    end
+  end
+end

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -25,6 +25,11 @@ class Commodity < GoodsNomenclature
            .filter("goods_nomenclatures.goods_nomenclature_item_id LIKE ?", chapter_id)
   }
 
+  one_to_many :search_references, key: :referenced_id, primary_key: :code, reciprocal: :referenced, conditions: { referenced_class: 'Commodity' },
+    adder: proc{ |search_reference| search_reference.update(referenced_id: code, referenced_class: 'Commodity') },
+    remover: proc{ |search_reference| search_reference.update(referenced_id: nil, referenced_class: nil)},
+    clearer: proc{ search_references_dataset.update(referenced_id: nil, referenced_class: nil) }
+
   delegate :section, to: :chapter
 
   # Tire configuration
@@ -128,7 +133,7 @@ class Commodity < GoodsNomenclature
     goods_nomenclature_item_id
   end
 
-  def to_indexed_json
+  def serializable_hash
     commodity_attributes = {
       id: goods_nomenclature_sid,
       goods_nomenclature_item_id: goods_nomenclature_item_id,
@@ -176,7 +181,11 @@ class Commodity < GoodsNomenclature
       end
     end
 
-    commodity_attributes.to_json
+    commodity_attributes
+  end
+
+  def to_indexed_json
+    serializable_hash.to_json
   end
 
   def self.changes_for(depth = 0, conditions = {})

--- a/app/services/search_service/fuzzy_search/reference_match.rb
+++ b/app/services/search_service/fuzzy_search/reference_match.rb
@@ -24,12 +24,19 @@ class SearchService
                                                      .all
       end
 
+      def commodities
+        @commodities ||= ResultQuery.new(search_results).for('Commodity')
+                                                        .uniq_by('goods_nomenclature_item_id')
+                                                        .sort_by('goods_nomenclature_item_id')
+                                                        .all
+      end
+
       def serializable_hash
         {
           sections: sections,
           chapters: chapters,
           headings: headings,
-          commodities: []
+          commodities: commodities
         }
       end
 

--- a/app/views/api/v1/search_references_base/_commodity.json.rabl
+++ b/app/views/api/v1/search_references_base/_commodity.json.rabl
@@ -1,0 +1,1 @@
+attributes :goods_nomenclature_sid

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,10 @@ TradeTariffBackend::Application.routes.draw do
         member {
           get :changes
         }
+
+        scope module: 'commodities', constraints: { commodity_id: /\d{10}/, id: /\d+/ } do
+          resources :search_references
+        end
       end
 
       resources :geographical_areas, only: [:countries] do

--- a/spec/controllers/api/v1/commodities/search_references_controller_spec.rb
+++ b/spec/controllers/api/v1/commodities/search_references_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Api::V1::Commodities::SearchReferencesController, "GET #index" do
+  it_behaves_like 'search references controller' do
+    let(:search_reference_parent)  { create :commodity, :declarable }
+    let(:search_reference)         { create :search_reference, commodity_id: search_reference_parent.code }
+    let(:collection_query)         {
+      { commodity_id: search_reference_parent.goods_nomenclature_item_id }
+    }
+    let(:resource_query)           {
+      collection_query.merge(id: search_reference.id)
+    }
+  end
+end


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/58810758

Adds synonyms on commodities. Been waiting to raise this PR until https://github.com/alphagov/trade-tariff-backend/pull/128 was merged in.

This depends on:
- https://github.com/alphagov/trade-tariff-admin/pull/17
- https://github.com/alphagov/trade-tariff-frontend/pull/111
