### PR TITLE
Use locally running Elasticsearch instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ bundler_args: --without development
 before_script:
    - mysql -e 'CREATE DATABASE tariff_test;'
 before_install:
-   - export PATH=$PATH:/usr/share/elasticsearch/bin/
    - sudo apt-get update -qq
    - sudo apt-get install -qq wbritish
    - cp config/database.travis.yml config/database.yml
@@ -18,10 +17,9 @@ script:
 rvm:
   - 2.0.0
   - 1.9.3
-  - 1.9.2
 matrix:
   allow_failures:
-    - rvm: 2.0.0
+    - rvm: 2.1.0
 branches:
   except:
     - release

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,13 +43,9 @@ TradeTariffBackend::Application.configure do
 
   config.after_initialize do
     TradeTariffBackend.configure do |tariff|
-      tariff.search_namespace = 'tariff-test'
-      # Run on different port then default 9200 in order to avoid
-      # conflicts with other environments
-      tariff.search_port = 9350
+      tariff.search_namespace = 'tariff-test' # default is just tariff
       tariff.search_options = {
-        log: false,
-        command: `which elasticsearch`.strip
+        log: false
       }
       # We need search index to be refreshed after each operation
       # in order to assert record presence in the index (in integration specs)

--- a/spec/support/elasticsearch.rb
+++ b/spec/support/elasticsearch.rb
@@ -1,15 +1,5 @@
 RSpec.configure do |config|
   config.before(:suite) do
-    Elasticsearch::Extensions::Test::Cluster.start \
-      cluster_name: TradeTariffBackend.search_namespace,
-      nodes:        1,
-      port:         TradeTariffBackend.search_port
-
     TradeTariffBackend.search_client.reindex
-  end
-
-  config.after(:suite) do
-    Elasticsearch::Extensions::Test::Cluster.stop \
-      port:         TradeTariffBackend.search_port
   end
 end


### PR DESCRIPTION
This is additional change for https://www.pivotaltracker.com/story/show/59667324

Doesn't spawn own instance of test cluster
Create Elasticsearch indexes before running specs

Also, for Travis:
- Run on Ruby 2.1 with allowed failure
- Don't run on 1.9.2 any more as we are on 1.9.3
