### PR TITLE
API Endpoint to update the national Measure Types

### DIFF
--- a/app/controllers/api/v1/measure_types_controller.rb
+++ b/app/controllers/api/v1/measure_types_controller.rb
@@ -1,0 +1,37 @@
+module Api
+  module V1
+    class MeasureTypesController < ApiController
+      before_filter :authenticate_user!
+
+      def index
+        @measure_types = MeasureType.eager(:measure_type_description).national.all
+
+        respond_with @measure_types
+      end
+
+      def show
+        @measure_type = MeasureType.national.with_pk!(measure_type_pk)
+      end
+
+      def update
+        @measure_type = MeasureType.national.with_pk!(measure_type_pk)
+        @measure_type.measure_type_description.tap do |measure_type_description|
+          measure_type_description.set(measure_type_params)
+          measure_type_description.save
+        end
+
+        respond_with @measure_type
+      end
+
+      private
+
+      def measure_type_params
+        params.require(:measure_type).permit(:description)
+      end
+
+      def measure_type_pk
+        params.fetch(:id, '')
+      end
+    end
+  end
+end

--- a/app/views/api/v1/measure_types/_measure_type.json.rabl
+++ b/app/views/api/v1/measure_types/_measure_type.json.rabl
@@ -1,0 +1,5 @@
+attributes :validity_start_date,
+           :validity_end_date
+
+node(:id) { |measure_type| measure_type.measure_type_id }
+node(:description) { |measure_type| measure_type.description }

--- a/app/views/api/v1/measure_types/index.json.rabl
+++ b/app/views/api/v1/measure_types/index.json.rabl
@@ -1,0 +1,7 @@
+collection @measure_types
+
+attributes :validity_start_date,
+           :validity_end_date
+
+node(:id) { |measure_type| measure_type.measure_type_id }
+node(:description) { |measure_type| measure_type.description }

--- a/app/views/api/v1/measure_types/show.json.rabl
+++ b/app/views/api/v1/measure_types/show.json.rabl
@@ -1,0 +1,3 @@
+object @measure_type
+
+extends('api/v1/measure_types/measure_type')

--- a/app/views/api/v1/measure_types/update.json.rabl
+++ b/app/views/api/v1/measure_types/update.json.rabl
@@ -1,0 +1,3 @@
+object @measure_type
+
+extends('api/v1/measure_types/measure_type')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ TradeTariffBackend::Application.routes.draw do
 
       resources :rollbacks, only: [:create, :index]
       resources :footnotes, only: [:index, :show, :update]
+      resources :measure_types, only: [:index, :show, :update]
     end
   end
 

--- a/spec/controllers/api/v1/measure_types_controller_spec.rb
+++ b/spec/controllers/api/v1/measure_types_controller_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe Api::V1::MeasureTypesController, "GET to #index" do
+  render_views
+
+  let!(:national_measure_type) { create :measure_type, :national }
+  let!(:non_national_measure_type) { create :measure_type, :non_national }
+
+  before { login_as_api_user }
+
+  let(:response_pattern) {
+    [
+      {
+        id: String,
+        validity_start_date: String,
+        description: String
+      }.ignore_extra_keys!
+    ]
+  }
+
+  let(:json_body) {
+    JSON.parse(response.body)
+  }
+
+  specify 'returns national measure types' do
+    get :index, format: :json
+    expect(response.body).to match_json_expression response_pattern
+    expect(json_body.map { |f| f["id"] }).to include national_measure_type.pk
+  end
+
+  specify 'does not return non-national measure type' do
+    get :index, format: :json
+
+    expect(json_body.map { |f| f["id"] }).not_to include non_national_measure_type.pk
+  end
+end
+
+describe Api::V1::MeasureTypesController, "GET to #show" do
+  render_views
+
+  let!(:national_measure_type) { create :measure_type, :national }
+  let!(:non_national_measure_type) { create :measure_type, :non_national }
+
+  before { login_as_api_user }
+
+  let(:response_pattern) {
+    {
+      id: String,
+      validity_start_date: String,
+      description: String
+    }.ignore_extra_keys!
+  }
+
+  specify 'returns national measure types' do
+    get :show, id: national_measure_type.pk, format: :json
+
+    expect(response.body).to match_json_expression response_pattern
+  end
+
+  specify 'does not return non-national measure types' do
+    get :show, id: non_national_measure_type.pk, format: :json
+
+    expect(response.status).to eq 404
+  end
+end
+
+describe Api::V1::MeasureTypesController, "PUT to #update" do
+  render_views
+
+  before { login_as_api_user }
+
+  let!(:national_measure_type) { create :measure_type, :national }
+  let!(:non_national_measure_type) { create :measure_type, :non_national }
+
+  specify 'updates national measure type' do
+    expect {
+      put :update, id: national_measure_type.pk, measure_type: { description: 'new description' }, format: :json
+    }.to change { national_measure_type.reload.description }.to('new description')
+  end
+
+  specify 'does not update non-national measure type' do
+    put :update, id: non_national_measure_type.pk, measure_type: {}, format: :json
+
+    expect(response.status).to eq 404
+  end
+end

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -126,6 +126,14 @@ FactoryGirl.define do
       trade_movement_code { 0 }
     end
 
+    trait :national do
+      national { true }
+    end
+
+    trait :non_national do
+      national { false }
+    end
+
     after(:build) { |measure_type, evaluator|
       FactoryGirl.create(:measure_type_series, measure_type_series_id: measure_type.measure_type_series_id)
     }


### PR DESCRIPTION
The footnote description is not enough as usually the same details are
on the national measure types
