### PR TITLE
Measure change feeds does not return proactively added measures

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -143,13 +143,17 @@ class Commodity < GoodsNomenclature
       :operation,
       Sequel.as(depth, :depth)
     ).where(pk_hash)
-     .union(Measure.changes_for(depth + 1, Sequel.qualify(:measures_oplog, :goods_nomenclature_item_id) => goods_nomenclature_item_id))
+     .union(
+       Measure.changes_for(
+         depth + 1,
+         Sequel.qualify(:measures_oplog, :goods_nomenclature_item_id) => goods_nomenclature_item_id)
+     )
      .from_self
      .where(Sequel.~(operation_date: nil))
      .tap! { |criteria|
        # if Commodity did not come from initial seed, filter by its
        # create/update date
-       criteria.where{ |o| o.>=(:operation_date, operation_date) } unless operation_date.blank?
+       criteria.where { |o| o.>=(:operation_date, operation_date) } unless operation_date.blank?
       }
      .limit(TradeTariffBackend.change_count)
      .order(Sequel.function(:isnull, :operation_date), Sequel.desc(:operation_date), Sequel.desc(:depth))

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -347,6 +347,7 @@ class Measure < Sequel::Model
       :operation,
       Sequel.as(depth, :depth)
     ).where(conditions)
+     .where { |o| o.<=(:validity_start_date, point_in_time) }
      .limit(TradeTariffBackend.change_count)
      .order(Sequel.function(:isnull, :operation_date), Sequel.desc(:operation_date))
   end

--- a/app/views/api/v1/changes/changes.json.rabl
+++ b/app/views/api/v1/changes/changes.json.rabl
@@ -1,6 +1,6 @@
 collection @changes
 
-attributes :oid, :model_name, :operation_date, :operation
+attributes :oid, :model_name, :operation, :operation_date
 
 node(:record) { |change|
   partial "api/v1/#{change.to_partial_path}", object: change.record

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -936,4 +936,27 @@ describe Measure do
       end
     end
   end
+
+  describe '.changes_for' do
+    context 'measure validity start date lower than requested date' do
+      let!(:measure) { create :measure, validity_start_date: Date.new(2014,2,1) }
+
+      it 'incudes measure' do
+        TimeMachine.at(Date.new(2014,1,30)) do
+          expect(Measure.changes_for).to be_empty
+        end
+      end
+    end
+
+    context 'measure validity start date higher than requested date' do
+      let!(:measure) { create :measure, validity_start_date: Date.new(2014,2,1) }
+
+      it 'does not include measure' do
+        TimeMachine.at(Date.new(2014,2,1)) do
+          expect(Measure.changes_for).not_to be_empty
+          expect(Measure.changes_for.first.oid).to eq measure.source.oid
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/64645912

How to reproduce? https://www.gov.uk/trade-tariff/commodities/1006209600/changes?as_of=2013-01-31

If I'm querying for commodity changes on 31st of Jan, I should not be seeing Measures that were added on 24th of Jan but have validity start date of 1st of Feb. Showing these causes issues with associations like measure type, because we expect measure type of such measure to be valid at query date (31st of Jan) and if they were introduced at the same time that is not the case (also has validity start date of 1st of Feb).
