### PR TITLE
Make sure we match all words in synonym search

### DIFF
--- a/app/services/search_service/fuzzy_search/reference_query.rb
+++ b/app/services/search_service/fuzzy_search/reference_query.rb
@@ -11,7 +11,8 @@ class SearchService
                 query: {
                   multi_match: {
                     query: query_string,
-                    fields: ['title']
+                    fields: ['title'],
+                    operator: 'and' # all terms must be present
                   }
                 },
                 filter: {


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/65968390

This narrows down synonym search results. When searching for 'acid oil' we use to find synonyms that either contain acid or oil but that's not really accurate. Changed the operator to search for 'acid' AND 'oil' in the synonym title.
