### PR TITLE
Restrict API methods

### DIFF
--- a/app/controllers/api/v1/search_references_base_controller.rb
+++ b/app/controllers/api/v1/search_references_base_controller.rb
@@ -26,10 +26,6 @@ module Api
         @search_reference = search_reference_resource
       end
 
-      def destroy
-        @search_reference = search_reference_resource
-      end
-
       def create
         @search_reference = SearchReference.new(
           search_reference_params.merge(search_reference_resource_association_hash)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,8 @@ TradeTariffBackend::Application.routes.draw do
     scope module: :v1, constraints: ApiConstraints.new(version: 1, default: true) do
       resources :sections, only: [:index, :show], constraints: { id: /\d{1,2}/ } do
         scope module: 'sections', constraints: { section_id: /\d{1,2}/, id: /\d+/ } do
-          resource :section_note
-          resources :search_references
+          resource :section_note, only: [:show, :create, :update, :destroy]
+          resources :search_references, only: [:show, :index, :destroy, :create, :update]
         end
       end
 
@@ -20,8 +20,8 @@ TradeTariffBackend::Application.routes.draw do
         }
 
         scope module: 'chapters', constraints: { chapter_id: /\d{2}/, id: /\d+/ } do
-          resource :chapter_note
-          resources :search_references
+          resource :chapter_note, only: [:show, :create, :update, :destroy]
+          resources :search_references, only: [:show, :index, :destroy, :create, :update]
         end
       end
 
@@ -31,7 +31,7 @@ TradeTariffBackend::Application.routes.draw do
         }
 
         scope module: 'headings', constraints: { heading_id: /\d{4}/, id: /\d+/ } do
-          resources :search_references
+          resources :search_references, only: [:show, :index, :destroy, :create, :update]
         end
       end
 
@@ -41,7 +41,7 @@ TradeTariffBackend::Application.routes.draw do
         }
 
         scope module: 'commodities', constraints: { commodity_id: /\d{10}/, id: /\d+/ } do
-          resources :search_references
+          resources :search_references, only: [:show, :index, :destroy, :create, :update]
         end
       end
 


### PR DESCRIPTION
List only used actions. It is better to show 404 than raise an exception saying that action was not implemented on the controller. Noticed this while documenting the api.
