### PR TITLE
Retry downloading update if update file is missing

### DIFF
--- a/app/views/tariff_synchronizer/mailer/file_not_found_on_filesystem.html.erb
+++ b/app/views/tariff_synchronizer/mailer/file_not_found_on_filesystem.html.erb
@@ -1,7 +1,7 @@
 <p>Hello,</p>
 
 <p>
-  Tried to apply update at <%= @path %> but the file was not found.
+  Tried to apply update at <%= @path %> but the file was not found. Trying to redownload.
 </p>
 
 <strong>Possible causes:</strong>

--- a/lib/tariff_synchronizer/chief_update.rb
+++ b/lib/tariff_synchronizer/chief_update.rb
@@ -35,10 +35,10 @@ module TariffSynchronizer
       end
     end
 
-    def apply
+    def apply(importer = ChiefImporter)
       if super
         instrument("apply_chief.tariff_synchronizer", filename: filename) do
-          ChiefImporter.new(file_path, issue_date).import
+          importer.new(file_path, issue_date).import
 
           mark_as_applied
         end

--- a/lib/tariff_synchronizer/taric_update.rb
+++ b/lib/tariff_synchronizer/taric_update.rb
@@ -51,10 +51,10 @@ module TariffSynchronizer
       end
     end
 
-    def apply
+    def apply(importer = TaricImporter)
       if super
         instrument("apply_taric.tariff_synchronizer", filename: filename) do
-          TaricImporter.new(file_path, issue_date).import
+          importer.new(file_path, issue_date).import
 
           mark_as_applied
         end

--- a/spec/unit/tariff_synchronizer/logger_spec.rb
+++ b/spec/unit/tariff_synchronizer/logger_spec.rb
@@ -289,8 +289,15 @@ describe TariffSynchronizer::Logger do
 
   describe '#not_found_on_file_system logging' do
     let(:taric_update) { create :taric_update }
+    let(:importer)     { double('importer', import: true).as_null_object }
 
-    before { taric_update.apply }
+    before do
+      TariffSynchronizer::TaricUpdate.should_receive(:download)
+                                     .with(taric_update.issue_date)
+                                     .and_return(true)
+
+      taric_update.apply(importer)
+    end
 
     it 'logs an error event' do
       @logger.logged(:error).size.should eq 1
@@ -301,6 +308,10 @@ describe TariffSynchronizer::Logger do
       ActionMailer::Base.deliveries.should_not be_empty
       email = ActionMailer::Base.deliveries.last
       email.encoded.should =~ /was not found/
+    end
+
+    it 'applies the update' do
+      expect(importer).to have_received :new
     end
   end
 


### PR DESCRIPTION
This change is for https://www.pivotaltracker.com/story/show/65969536

When Tariff runs in multi-server environment one server may have downloaded the update and marked as pending. If other server tries to apply it, it won't find the file. Therefore we try to redownload the update if file is missing.

It would be better to have  a shared file storage like S3 though.
