### PR TITLE
Reduce the verbosity of elasticsearch logging

### DIFF
--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -122,7 +122,7 @@ module TradeTariffBackend
     attr_writer :search_port
 
     def default_search_options
-      { host: search_host, log: true }
+      { host: search_host, logger: Rails.logger }
     end
 
     def search_options


### PR DESCRIPTION
This switches the elasticsearch logging from STDERR to Rails' logger.
This means that the logging level will be appropriate to the environment.

Errors in production were obscured by huge quantities of successful requests
which often have large bodies.
