### PR TITLE
Remove the elasticsearch plugin on models that are inherited from GoodsNomenclature

### DIFF
--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -3,7 +3,6 @@ require_relative 'goods_nomenclature'
 class Chapter < GoodsNomenclature
   plugin :oplog, primary_key: :goods_nomenclature_sid
   plugin :conformance_validator
-  plugin :elasticsearch
 
   set_dataset filter("goods_nomenclatures.goods_nomenclature_item_id LIKE ?", '__00000000').
               order(Sequel.asc(:goods_nomenclature_item_id))

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -6,7 +6,6 @@ class Commodity < GoodsNomenclature
 
   plugin :oplog, primary_key: :goods_nomenclature_sid
   plugin :conformance_validator
-  plugin :elasticsearch
 
   set_dataset filter("goods_nomenclatures.goods_nomenclature_item_id NOT LIKE ?", '____000000').
               order(Sequel.asc(:goods_nomenclatures__goods_nomenclature_item_id))

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -6,7 +6,6 @@ class Heading < GoodsNomenclature
 
   plugin :oplog, primary_key: :goods_nomenclature_sid
   plugin :conformance_validator
-  plugin :elasticsearch
 
   set_dataset filter("goods_nomenclatures.goods_nomenclature_item_id LIKE ?", '____000000').
               filter("goods_nomenclatures.goods_nomenclature_item_id NOT LIKE ?", '__00______').


### PR DESCRIPTION
There is an issue when you try and recreate your DB from scratch where delete calls will be made to documents not in ES that will cause the whole sync process to crash. This is because this plugin uses the `after_destroy` callback.

This removes the sequel plugin from models which are already indexed as part of the sync process `TradeTariffBackend.reindex`.
