### PR TITLE
Do not show section duplicates when searching via synonyms

### DIFF
--- a/app/services/search_service/fuzzy_search.rb
+++ b/app/services/search_service/fuzzy_search.rb
@@ -9,6 +9,15 @@ class SearchService
       begin
         @results ||= begin
           FuzzySearchResult.new(query_string, date).each_with_object({}) do |(match_type, search_index, results), memo|
+
+            results.uniq! do |result|
+              if result["_source"].has_key?("reference")
+                result["_source"]["reference"]["id"]
+              else
+                result
+              end
+            end
+
             memo.deep_merge!({
               match_type => { search_index.type.pluralize => results }
             })

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -387,6 +387,34 @@ describe SearchService do
         expect(result.to_json).to match_json_expression response_pattern
       end
     end
+
+    context "searching with synonyms" do
+      include SynonymsHelper
+
+      let(:synonym) { "synonym 1" }
+      let(:resources) { %w(section chapter heading commodity) }
+      let(:reference_match) {
+        SearchService.new(t: synonym, as_of: Date.today).send(:perform).results[:reference_match]
+      }
+
+      before {
+        # create resources with synonyms
+        resources.each do |resource|
+          create(resource).tap{ |r|
+            2.times do
+              create_synonym_for(r, synonym)
+            end
+          }
+        end
+      }
+
+      # there shouldn't be duplicates
+      it "shouldn't have duplicates" do
+        resources.each do |r|
+          expect(reference_match[r.pluralize].count).to eq(1)
+        end
+      end
+    end
   end
 
   context 'reference search' do

--- a/spec/support/synonyms_helper.rb
+++ b/spec/support/synonyms_helper.rb
@@ -1,0 +1,5 @@
+module SynonymsHelper
+  def create_synonym_for(reference, title="synonym")
+    create(:search_reference, title: title, referenced: reference)
+  end
+end


### PR DESCRIPTION
> If we assign two synonyms to the same location (heading, commodity) when we search the result appears twice.
> We should dedup the response, so we only show one result, per location.

[pivotal story](https://www.pivotaltracker.com/n/projects/488191/stories/68999382)
