### PR TITLE
switch from `curb` to `faraday`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'gds-sso', '3.1.0'
 gem "railties"
 
 gem "unicorn", "~> 4.6.3"
-gem "curb", "0.8.3"
+gem "faraday", "~> 0.8.8"
 
 gem "nokogiri", "1.5.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,6 @@ GEM
     coderay (1.0.9)
     connection_pool (1.2.0)
     crack (0.3.2)
-    curb (0.8.3)
     database_cleaner (1.2.0)
     diff-lcs (1.2.4)
     elasticsearch (0.4.7)
@@ -301,12 +300,12 @@ DEPENDENCIES
   builder
   capistrano
   ci_reporter
-  curb (= 0.8.3)
   database_cleaner
   elasticsearch (= 0.4.7)
   elasticsearch-extensions (= 0.0.12)
   factory_girl_rails
   fakefs
+  faraday (~> 0.8.8)
   forgery
   gds-sso (= 3.1.0)
   guard-rspec

--- a/app/views/tariff_synchronizer/mailer/failed_download.html.erb
+++ b/app/views/tariff_synchronizer/mailer/failed_download.html.erb
@@ -5,7 +5,7 @@
 </p>
 
 <p>
-  <strong><%= @exception %></strong>
+  <strong><%= @exception %> (<%= @exception.class %>)</strong>
 </p>
 
 <p>

--- a/spec/unit/tariff_synchronizer/logger_spec.rb
+++ b/spec/unit/tariff_synchronizer/logger_spec.rb
@@ -204,13 +204,13 @@ describe TariffSynchronizer::Logger do
   end
 
   describe '#failed_download logging' do
-    before {
-       TariffSynchronizer.retry_count = 0
-       TariffSynchronizer.stub(:sync_variables_set?).and_return(true)
+    let(:error) { Faraday::Error::ClientError.new(nil) }
 
-       Curl::Easy.any_instance
-                 .should_receive(:perform)
-                 .and_raise(Curl::Err::HostResolutionError)
+    before {
+      TariffSynchronizer.retry_count = 0
+      TariffSynchronizer.stub(:sync_variables_set?).and_return(true)
+
+      Faraday::Connection.any_instance.should_receive(:get).and_raise(error)
 
       rescuing { TariffSynchronizer.download }
     }
@@ -228,7 +228,7 @@ describe TariffSynchronizer::Logger do
 
     it 'email includes information about exception' do
       email = ActionMailer::Base.deliveries.last
-      email.encoded.should =~ /Curl::Err::HostResolutionError/
+      email.encoded.should =~ /Faraday::Error::ClientError/
     end
   end
 

--- a/spec/unit/tariff_synchronizer_spec.rb
+++ b/spec/unit/tariff_synchronizer_spec.rb
@@ -39,15 +39,17 @@ describe TariffSynchronizer do
     end
 
     context 'with download exceptions' do
+      let(:error) { Faraday::Error::ClientError.new(nil) }
+
       before {
         TariffSynchronizer.should_receive(:sync_variables_set?).and_return(true)
 
-        Curl::Easy.any_instance
-                  .should_receive(:perform)
-                  .and_raise(Curl::Err::HostResolutionError) }
+        Faraday::Connection.any_instance
+                           .should_receive(:get)
+                           .and_raise(error) }
 
       it 'raises original exception ending process' do
-        expect { TariffSynchronizer.download }.to raise_error Curl::Err::HostResolutionError
+        expect { TariffSynchronizer.download }.to raise_error error.class
       end
     end
   end


### PR DESCRIPTION
Moving to `faraday` because curb sometimes raises _Host Resolution Error_

[pivotal story](https://www.pivotaltracker.com/n/projects/488191/stories/69001522)
