### PR TITLE
add GA5 and GA6 conformance rules

### DIFF
--- a/app/validators/geographical_area_validator.rb
+++ b/app/validators/geographical_area_validator.rb
@@ -35,10 +35,11 @@ class GeographicalAreaValidator < TradeTariffBackend::Validator
   validation :GA6, 'Loops in the parent relation between geographical areas and parent geographical area groups are not allowed. If a geographical area A is a parent geographical area group of B then B cannot be a parent geographical area group of A (loops can also exist on more than two levels, e.g. level 3; If A is a parent of B and B is a parent of C then C cannot be a parent of A).', on: [:create, :update] do |record|
     children_chain = [record.geographical_area_sid]
     if parent = record.parent_geographical_area
-      while parent = parent.parent_geographical_area && not @has_error
+      while parent && !@has_error
         sid = parent.geographical_area_sid
         @has_error ||= children_chain.include?(sid)
         children_chain << sid
+        parent = parent.parent_geographical_area
       end
     end
     !@has_error


### PR DESCRIPTION
To `GeographicalArea`
**GA5**

> If a geographical area has a parent geographical area group then the validity period of the parent geographical area group must span the validity period of the geographical area.

Note: It won't complain if dates aren't present

**GA6**

> Loops in the parent relation between geographical areas and parent geographical area groups are not allowed. If a geographical area A is a parent geographical area group of B then B cannot be a parent geographical area group of A (loops can also exist on more than two levels, e.g. level 3; If A is a parent of B and B is a parent of C then C cannot be a parent of A)
