### PR TITLE
fix specs

### DIFF
--- a/app/validators/geographical_area_validator.rb
+++ b/app/validators/geographical_area_validator.rb
@@ -33,12 +33,14 @@ class GeographicalAreaValidator < TradeTariffBackend::Validator
   end
 
   validation :GA6, 'Loops in the parent relation between geographical areas and parent geographical area groups are not allowed. If a geographical area A is a parent geographical area group of B then B cannot be a parent geographical area group of A (loops can also exist on more than two levels, e.g. level 3; If A is a parent of B and B is a parent of C then C cannot be a parent of A).', on: [:create, :update] do |record|
-    children_chain = [record.geographical_area_sid]
+    children_chain = []
+    children_chain << record.geographical_area_sid if record.geographical_area_sid
     if parent = record.parent_geographical_area
       while parent && !@has_error
-        sid = parent.geographical_area_sid
-        @has_error ||= children_chain.include?(sid)
-        children_chain << sid
+        if sid = parent.geographical_area_sid
+          @has_error ||= children_chain.include?(sid)
+          children_chain << sid
+        end
         parent = parent.parent_geographical_area
       end
     end

--- a/spec/models/geographical_area_spec.rb
+++ b/spec/models/geographical_area_spec.rb
@@ -248,7 +248,7 @@ describe GeographicalArea do
           }
 
           it {
-            expect(geographical_area.conformance_errors).to be_empty
+            expect(geographical_area.conformance_errors).to_not have_key(:GA5)
           }
         end
 
@@ -260,7 +260,7 @@ describe GeographicalArea do
           }
 
           it {
-            expect(geographical_area.conformance_errors).to be_empty
+            expect(geographical_area.conformance_errors).to_not have_key(:GA5)
           }
         end
 
@@ -277,7 +277,7 @@ describe GeographicalArea do
           }
 
           it {
-            expect(geographical_area.conformance_errors).to be_empty
+            expect(geographical_area.conformance_errors).to_not have_key(:GA5)
           }
         end
       end


### PR DESCRIPTION
enhance specs:
- be more specific when looking into validations
- don't add `nil` values to `children_chain` when looping and looking for loops in geographical area's relationships

Should fix random failures with travis (see PR #170)
