### PR TITLE
Remove FACTER_govuk_platform

### DIFF
--- a/lib/trade_tariff_backend.rb
+++ b/lib/trade_tariff_backend.rb
@@ -30,7 +30,7 @@ module TradeTariffBackend
     end
 
     def platform
-      ENV["FACTER_govuk_platform"] || Rails.env
+      Rails.env
     end
 
     def deployed_environment

--- a/spec/unit/trade_tariff_backend_spec.rb
+++ b/spec/unit/trade_tariff_backend_spec.rb
@@ -31,19 +31,7 @@ describe TradeTariffBackend do
   end
 
   describe '.platform' do
-    context 'FACTER_govuk_platform environment variable available' do
-
-      before { ENV['FACTER_govuk_platform'] = 'production' }
-      after  { ENV['FACTER_govuk_platform'] = nil }
-
-      it 'returns the environment variable value' do
-        expect(TradeTariffBackend.platform).to eq 'production'
-      end
-    end
-
-    context 'FACTER_govuk_platform environment variable unavailable' do
-      before { ENV['FACTER_govuk_platform'] = nil }
-
+    context 'platform should be Rails.env' do
       it 'defaults to Rails.env' do
         expect(TradeTariffBackend.platform).to eq Rails.env
       end


### PR DESCRIPTION
This environment variable is set by puppet. It should not be used by applications and it is being removed from our environment.

I have:
- replaced ENV['FACTER_govuk_platform'] in the code
- removed a test for it
- removed the legacy router.rake task completely (it's not used)

This fixes #179
