### PR TITLE
Removing PK on validity_start_date for FootnoteAssociationGoodsNomenclature

### DIFF
--- a/app/models/footnote_association_goods_nomenclature.rb
+++ b/app/models/footnote_association_goods_nomenclature.rb
@@ -2,11 +2,10 @@ class FootnoteAssociationGoodsNomenclature < Sequel::Model
   plugin :time_machine
   plugin :oplog, primary_key: [:footnote_id,
                                :footnote_type,
-                               :goods_nomenclature_sid,
-                               :validity_start_date]
+                               :goods_nomenclature_sid]
   plugin :conformance_validator
 
-  set_primary_key [:footnote_id, :footnote_type, :goods_nomenclature_sid, :validity_start_date]
+  set_primary_key [:footnote_id, :footnote_type, :goods_nomenclature_sid]
 end
 
 


### PR DESCRIPTION
This is to fix an error with the TARIC sync which failed on 2014-07-23
where a FootnoteAssociationGoodsNomenclature's validity_start_date was
being updated, this causes an issue because when updating we use the
primary key to fetch the record being updated. As the attribute being
updated was part of the primary key, the record was not found and
halted the sync.

We will have to review all other instances of validity_start_date in a
primary key to ensure that this doesn't halt the import in the future.
