### PR TITLE
Measurement unit abbreviation enhances

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -314,6 +314,15 @@ class Measure < Sequel::Model
     measure_components.map(&:duty_expression_str).join(" ")
   end
 
+  def duty_expression_with_national_measurement_units_for(declarable)
+    national_measurement_units = national_measurement_units_for(declarable)
+    if national_measurement_units.present?
+      "#{duty_expression} [#{national_measurement_units.join(" - ")}]"
+    else
+      duty_expression
+    end
+  end
+
   def formatted_duty_expression
     measure_components.map(&:formatted_duty_expression).join(" ")
   end
@@ -325,6 +334,15 @@ class Measure < Sequel::Model
                 .select(&:present?)
                 .select{ |nmu| nmu.level > 1 }
                 .map(&:to_s)
+    end
+  end
+
+  def formatted_duty_expression_with_national_measurement_units_for(declarable)
+    national_measurement_units = national_measurement_units_for(declarable)
+    if national_measurement_units.present?
+      "#{formatted_duty_expression} [#{national_measurement_units.join(" - ")}]"
+    else
+      formatted_duty_expression
     end
   end
 

--- a/app/views/api/v1/measures/_measure.json.rabl
+++ b/app/views/api/v1/measures/_measure.json.rabl
@@ -15,9 +15,8 @@ node(:measure_type) { |measure|
 }
 node(:duty_expression) { |measure|
   {
-    base: measure.duty_expression,
-    formatted_base: measure.formatted_duty_expression,
-    national_measurement_units: measure.national_measurement_units_for(locals[:declarable])
+    base: measure.duty_expression_with_national_measurement_units_for(locals[:declarable]),
+    formatted_base: measure.formatted_duty_expression_with_national_measurement_units_for(locals[:declarable])
   }
 }
 

--- a/spec/factories/duty_expression_factory.rb
+++ b/spec/factories/duty_expression_factory.rb
@@ -5,6 +5,12 @@ FactoryGirl.define do
     duty_expression_id  { generate(:duty_expression_description) }
     validity_start_date { Date.today.ago(3.years) }
     validity_end_date   { nil }
+
+    trait :with_description do
+      after(:create) do |duty_expression, evaluator|
+        FactoryGirl.create(:duty_expression_description, duty_expression_id: duty_expression.duty_expression_id)
+      end
+    end
   end
 
   factory :duty_expression_description do

--- a/spec/factories/measure_factory.rb
+++ b/spec/factories/measure_factory.rb
@@ -134,6 +134,10 @@ FactoryGirl.define do
       national { false }
     end
 
+    trait :excise do
+      measure_type_description "EXCISE 111"
+    end
+
     after(:build) { |measure_type, evaluator|
       FactoryGirl.create(:measure_type_series, measure_type_series_id: measure_type.measure_type_series_id)
     }

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -959,4 +959,65 @@ describe Measure do
       end
     end
   end
+
+  describe "#duty_expression_with_national_measurement_units_for ^ #formatted_duty_expression_with_national_measurement_units_for" do
+    let(:commodity) {
+      create :commodity
+    }
+    let(:base) {
+      measure.duty_expression_with_national_measurement_units_for(commodity)
+    }
+    let(:formatted_base) {
+      measure.formatted_duty_expression_with_national_measurement_units_for(commodity)
+    }
+    let(:measure_type) {
+      create :measure_type, :excise
+    }
+    let(:measure) {
+      create :measure, measure_type_id: measure_type.measure_type_id
+    }
+    let(:duty_expression) {
+      create(:duty_expression, :with_description)
+    }
+    let!(:measure_component) {
+      create :measure_component, measure_sid: measure.measure_sid,
+                                 duty_expression_id: duty_expression.duty_expression_id
+    }
+
+    context "without national_measurement_unit" do
+      it {
+        base.should =~ Regexp.new(measure_component.duty_expression_str)
+      }
+      it {
+        formatted_base.should =~ Regexp.new(measure_component.formatted_duty_expression)
+      }
+    end
+
+    context "with national_measurement_unit" do
+      let!(:comm1) { create :comm, cmdty_code: commodity.goods_nomenclature_item_id,
+                                   fe_tsmp: Date.today.ago(2.years),
+                                   le_tsmp: nil,
+                                   uoq_code_cdu2: tbl1.tbl_code,
+                                   uoq_code_cdu3: tbl2.tbl_code }
+      let(:tbl1) { create :tbl9, :unoq, tbl_code: 'aa1' }
+      let(:tbl2) { create :tbl9, :unoq, tbl_code: 'aa2' }
+
+      let(:national_measurement_units) {
+        measure.national_measurement_units_for(commodity)
+      }
+
+      it {
+        base.should =~ Regexp.new(measure_component.duty_expression_str)
+        national_measurement_units.each do |unit|
+          base.should =~ Regexp.new(unit)
+        end
+      }
+      it {
+        formatted_base.should =~ Regexp.new(measure_component.formatted_duty_expression)
+        national_measurement_units.each do |unit|
+          formatted_base.should =~ Regexp.new(unit)
+        end
+      }
+    end
+  end
 end


### PR DESCRIPTION
Include `national_measurement_units` as part of `formatted_base`
Include `national_measurement_units` as part of `base`

`national_measurement_units` won't be serialised anymore as part of api

This PR compliments alphagov/trade-tariff-frontend#139
