### PR TITLE
show missing abbreviation tags for `ps/t` abbreviation

### DIFF
--- a/app/formatters/duty_expression_formatter.rb
+++ b/app/formatters/duty_expression_formatter.rb
@@ -23,7 +23,11 @@ class DutyExpressionFormatter
       output = []
       case duty_expression_id
       when "99"
-        output << measurement_unit_abbreviation
+        if opts[:formatted]
+          output << "<abbr title='#{measurement_unit.description}'>#{measurement_unit_abbreviation}</abbr>"
+        else
+          output << "#{measurement_unit_abbreviation}"
+        end
       when "12", "14", "37", "40", "41", "42", "43", "44", "21", "25", "27", "29"
         if duty_expression_abbreviation.present?
           output << duty_expression_abbreviation


### PR DESCRIPTION
duty_expression_id 99, is a special case as it doesn't have any other units, it should show the abbreviation and full description in the abbreviation tag.

![screen_shot_2014-08-05_at_12 04 03_pm](https://cloud.githubusercontent.com/assets/215/3815288/14b55d54-1cc3-11e4-8bc7-06bfe95e675f.png)
