### PR TITLE
Enhance `NationalMeasurementUnit` view

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -317,7 +317,7 @@ class Measure < Sequel::Model
   def duty_expression_with_national_measurement_units_for(declarable)
     national_measurement_units = national_measurement_units_for(declarable)
     if national_measurement_units.present?
-      "#{duty_expression} [#{national_measurement_units.join(" - ")}]"
+      "#{duty_expression} (#{national_measurement_units.join(" - ")})"
     else
       duty_expression
     end
@@ -340,7 +340,7 @@ class Measure < Sequel::Model
   def formatted_duty_expression_with_national_measurement_units_for(declarable)
     national_measurement_units = national_measurement_units_for(declarable)
     if national_measurement_units.present?
-      "#{formatted_duty_expression} [#{national_measurement_units.join(" - ")}]"
+      "#{formatted_duty_expression} (#{national_measurement_units.join(" - ")})"
     else
       formatted_duty_expression
     end

--- a/app/models/national_measurement_unit.rb
+++ b/app/models/national_measurement_unit.rb
@@ -8,7 +8,7 @@ class NationalMeasurementUnit
   end
 
   def description
-    description_map.fetch(measurement_unit_code, @description.to_s.downcase.titlecase)
+    self.class.description_map.fetch(measurement_unit_code, nil)
   end
 
   def present?
@@ -19,9 +19,7 @@ class NationalMeasurementUnit
     description
   end
 
-  private
-
-  def description_map
+  def self.description_map
     {
      '048' => 'Hectokilogram Net Dry Matter (100kg/net mas)',
      '066' => 'Litre of Alcohol',

--- a/spec/factories/chief_record_factory.rb
+++ b/spec/factories/chief_record_factory.rb
@@ -410,9 +410,13 @@ FactoryGirl.define do
   end
 
   factory :tbl9, class: Chief::Tbl9 do
-    tbl_code { 3.times.map{ Random.rand(9) }.join }
     txtlnno  { 1 }
-    tbl_txt  { Forgery(:basic).text }
+    tbl_code { NationalMeasurementUnit.description_map.keys.sample }
+    tbl_txt  {
+      NationalMeasurementUnit.description_map.fetch(tbl_code) {
+        Forgery(:basic).text # random if not found on map
+      }
+    }
 
     trait :unoq do
       tbl_type { 'UNOQ' }

--- a/spec/models/measure_spec.rb
+++ b/spec/models/measure_spec.rb
@@ -898,8 +898,8 @@ describe Measure do
         let(:commodity) { create :commodity }
 
         context 'declarable has national measurement unit set associated' do
-          let(:tbl1) { create :tbl9, :unoq, tbl_code: 'aa1' }
-          let(:tbl2) { create :tbl9, :unoq, tbl_code: 'aa2' }
+          let(:tbl1) { create :tbl9, :unoq }
+          let(:tbl2) { create :tbl9, :unoq }
           let!(:comm1) { create :comm, cmdty_code: commodity.goods_nomenclature_item_id,
                                       fe_tsmp: Date.today.ago(2.years),
                                       le_tsmp: nil,


### PR DESCRIPTION
- show national measurement unit if available in map (see `NationalMeasurementUnit`)
- use parenthesis `(` instead of brackets `[`
