### PR TITLE
Apply the sync at 8 & 11 pm

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -3,6 +3,10 @@ set :output, { error: 'log/cron.error.log', standard: 'log/cron.log'}
 # We need Rake to use our own environment
 job_type :rake, "cd :path && /usr/local/bin/govuk_setenv tariff-api bundle exec rake :task --silent :output"
 
-every 1.hour do
+every 1.day, at: "8:00 pm" do
+  rake "tariff:sync:apply"
+end
+
+every 1.day, at: "11:00 pm" do
   rake "tariff:sync:apply"
 end


### PR DESCRIPTION
This is because the files are dropping in reverse order from HMRC.
Run this only later in the day to pick up both files at once and
apply them in the correct order
