### PR TITLE
sort rollbacks by `id` (desc)

### DIFF
--- a/app/models/rollback.rb
+++ b/app/models/rollback.rb
@@ -2,7 +2,7 @@ class Rollback < Sequel::Model
 
   dataset_module do
     def descending
-      order(Sequel.desc(:date))
+      order(Sequel.desc(:id))
     end
   end
   


### PR DESCRIPTION
so we deliver latest rollbacks first. - makes more sense
