### PR TITLE
follow rails autoloading rules

### DIFF
--- a/app/models/additional_code_description.rb
+++ b/app/models/additional_code_description.rb
@@ -1,7 +1,7 @@
 require 'formatter'
 
 class AdditionalCodeDescription < Sequel::Model
-  include Models::Formatter
+  include Formatter
 
   plugin :time_machine
   plugin :oplog, primary_key: [:additional_code_description_period_sid, :additional_code_sid]
@@ -18,5 +18,3 @@ class AdditionalCodeDescription < Sequel::Model
   # many_to_one :additional_code_type, key: :additional_code_type_id
   # many_to_one :additional_code, key: :additional_code_sid
 end
-
-

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -2,7 +2,7 @@ require 'formatter'
 require 'declarable'
 
 class Commodity < GoodsNomenclature
-  include Model::Declarable
+  include Declarable
 
   plugin :oplog, primary_key: :goods_nomenclature_sid
   plugin :conformance_validator

--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -1,96 +1,93 @@
-module Model
-  module Declarable
-    extend ActiveSupport::Concern
+module Declarable
+  extend ActiveSupport::Concern
+  include Formatter
 
-    included do
-      include Models::Formatter
+  included do
+    one_to_many :measures, primary_key: {}, key: {}, dataset: -> {
+       Measure.join(
+         Measure.with_base_regulations
+                .with_actual(BaseRegulation)
+                .where({measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid)})
+                .where{ Sequel.~(measures__measure_type_id: MeasureType::EXCLUDED_TYPES) }
+                .order(Sequel.asc(:measures__measure_sid)).tap! { |query|
+                 query.union(
+                        Measure.with_base_regulations
+                               .with_actual(BaseRegulation)
+                               .where({measures__export_refund_nomenclature_sid: export_refund_uptree.map(&:export_refund_nomenclature_sid)})
+                               .where{ Sequel.~(measures__measure_type_id: MeasureType::EXCLUDED_TYPES) }
+                               .order(Sequel.asc(:measures__measure_sid))
+                     ) if export_refund_uptree.present?
+                }
+        .union(
+         Measure.with_modification_regulations
+                .with_actual(ModificationRegulation)
+                .where({measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid)})
+                .where{ Sequel.~(measures__measure_type_id: MeasureType::EXCLUDED_TYPES) }
+                .order(Sequel.asc(:measures__measure_sid))
+                .tap! {|query|
+                  query.union(
+                        Measure.with_modification_regulations
+                               .with_actual(ModificationRegulation)
+                               .where({measures__export_refund_nomenclature_sid: export_refund_uptree.map(&:export_refund_nomenclature_sid)})
+                               .where{ Sequel.~(measures__measure_type_id: MeasureType::EXCLUDED_TYPES) }
+                               .order(Sequel.asc(:measures__measure_sid))
+                     ) if export_refund_uptree.present?
+                },
+          alias: :measures
+        )
+        .with_actual(Measure)
+        .order(Sequel.asc(:measures__geographical_area_id),
+               Sequel.desc(:effective_start_date)),
+        t1__measure_sid: :measures__measure_sid
+      ).group(:measures__measure_type_id,
+              :measures__geographical_area_sid,
+              :measures__measure_generating_regulation_id,
+              :measures__additional_code_type_id,
+              :measures__additional_code_id)
+    }
 
-      one_to_many :measures, primary_key: {}, key: {}, dataset: -> {
-         Measure.join(
-           Measure.with_base_regulations
-                  .with_actual(BaseRegulation)
-                  .where({measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid)})
-                  .where{ Sequel.~(measures__measure_type_id: MeasureType::EXCLUDED_TYPES) }
-                  .order(Sequel.asc(:measures__measure_sid)).tap! { |query|
-                   query.union(
-                          Measure.with_base_regulations
-                                 .with_actual(BaseRegulation)
-                                 .where({measures__export_refund_nomenclature_sid: export_refund_uptree.map(&:export_refund_nomenclature_sid)})
-                                 .where{ Sequel.~(measures__measure_type_id: MeasureType::EXCLUDED_TYPES) }
-                                 .order(Sequel.asc(:measures__measure_sid))
-                       ) if export_refund_uptree.present?
-                  }
-          .union(
-           Measure.with_modification_regulations
-                  .with_actual(ModificationRegulation)
-                  .where({measures__goods_nomenclature_sid: uptree.map(&:goods_nomenclature_sid)})
-                  .where{ Sequel.~(measures__measure_type_id: MeasureType::EXCLUDED_TYPES) }
-                  .order(Sequel.asc(:measures__measure_sid))
-                  .tap! {|query|
-                    query.union(
-                          Measure.with_modification_regulations
-                                 .with_actual(ModificationRegulation)
-                                 .where({measures__export_refund_nomenclature_sid: export_refund_uptree.map(&:export_refund_nomenclature_sid)})
-                                 .where{ Sequel.~(measures__measure_type_id: MeasureType::EXCLUDED_TYPES) }
-                                 .order(Sequel.asc(:measures__measure_sid))
-                       ) if export_refund_uptree.present?
-                  },
-            alias: :measures
-          )
-          .with_actual(Measure)
-          .order(Sequel.asc(:measures__geographical_area_id),
-                 Sequel.desc(:effective_start_date)),
-          t1__measure_sid: :measures__measure_sid
-        ).group(:measures__measure_type_id,
-                :measures__geographical_area_sid,
-                :measures__measure_generating_regulation_id,
-                :measures__additional_code_type_id,
-                :measures__additional_code_id)
-      }
+    one_to_many :import_measures, key: {}, primary_key: {}, dataset: -> {
+      measures_dataset.join(:measure_types, measure_types__measure_type_id: :measures__measure_type_id)
+                      .filter(measure_types__trade_movement_code: MeasureType::IMPORT_MOVEMENT_CODES)
+    }, class_name: 'Measure'
 
-      one_to_many :import_measures, key: {}, primary_key: {}, dataset: -> {
-        measures_dataset.join(:measure_types, measure_types__measure_type_id: :measures__measure_type_id)
-                        .filter(measure_types__trade_movement_code: MeasureType::IMPORT_MOVEMENT_CODES)
-      }, class_name: 'Measure'
+    one_to_many :export_measures, key: {}, primary_key: {}, dataset: -> {
+      measures_dataset.join(:measure_types, measure_types__measure_type_id: :measures__measure_type_id)
+                      .filter(measure_types__trade_movement_code: MeasureType::EXPORT_MOVEMENT_CODES)
+    }, class_name: 'Measure'
 
-      one_to_many :export_measures, key: {}, primary_key: {}, dataset: -> {
-        measures_dataset.join(:measure_types, measure_types__measure_type_id: :measures__measure_type_id)
-                        .filter(measure_types__trade_movement_code: MeasureType::EXPORT_MOVEMENT_CODES)
-      }, class_name: 'Measure'
-
-      one_to_many :basic_duty_rate_components, primary_key: {}, key: {}, class_name: 'MeasureComponent' do
-        MeasureComponent.where(measure: import_measures_dataset.where(measures__measure_type_id: MeasureType::THIRD_COUNTRY).all)
-      end
-
-      format :description_plain, with: DescriptionTrimFormatter,
-                                 using: :description
-      format :formatted_description, with: DescriptionFormatter,
-                                     using: :description
+    one_to_many :basic_duty_rate_components, primary_key: {}, key: {}, class_name: 'MeasureComponent' do
+      MeasureComponent.where(measure: import_measures_dataset.where(measures__measure_type_id: MeasureType::THIRD_COUNTRY).all)
     end
 
-    def export_refund_uptree
-      @_export_refund_uptree ||= export_refund_nomenclatures.map(&:uptree).flatten
-    end
-
-    def chapter_id
-      "#{goods_nomenclature_item_id.first(2)}00000000"
-    end
-
-    def consigned?
-      description =~ /consigned from/i
-    end
-
-    def consigned_from
-      description.scan(/consigned from ([a-zA-Z,' ]+)(?:\W|$)/i).join(", ") if consigned?
-    end
-
-    def basic_duty_rate
-      basic_duty_rate_components.map(&:formatted_duty_expression).join(" ")
-    end
-
-    def meursing_code?
-      measures.any?(&:meursing?)
-    end
-    alias :meursing_code :meursing_code?
+    format :description_plain, with: DescriptionTrimFormatter,
+                               using: :description
+    format :formatted_description, with: DescriptionFormatter,
+                                   using: :description
   end
+
+  def export_refund_uptree
+    @_export_refund_uptree ||= export_refund_nomenclatures.map(&:uptree).flatten
+  end
+
+  def chapter_id
+    "#{goods_nomenclature_item_id.first(2)}00000000"
+  end
+
+  def consigned?
+    description =~ /consigned from/i
+  end
+
+  def consigned_from
+    description.scan(/consigned from ([a-zA-Z,' ]+)(?:\W|$)/i).join(", ") if consigned?
+  end
+
+  def basic_duty_rate
+    basic_duty_rate_components.map(&:formatted_duty_expression).join(" ")
+  end
+
+  def meursing_code?
+    measures.any?(&:meursing?)
+  end
+  alias :meursing_code :meursing_code?
 end

--- a/app/models/concerns/formatter.rb
+++ b/app/models/concerns/formatter.rb
@@ -1,41 +1,39 @@
-module Models
-  module Formatter
-    extend ActiveSupport::Concern
+module Formatter
+  extend ActiveSupport::Concern
 
-    module ClassMethods
-      def format(attribute, options)
-        options.assert_valid_keys :with, :using, :defaults
+  module ClassMethods
+    def format(attribute, options)
+      options.assert_valid_keys :with, :using, :defaults
 
-        formatter, using, defaults = options.values_at(:with,
-                                                       :using,
-                                                       :defaults)
-        mod = Module.new do
-          define_method(attribute) do
-            opts = {}
+      formatter, using, defaults = options.values_at(:with,
+                                                     :using,
+                                                     :defaults)
+      mod = Module.new do
+        define_method(attribute) do
+          opts = {}
 
-            [using].flatten.each do |field|
-              opts[field] = result_of_attribute_or_method_call(field)
-            end if using.present?
+          [using].flatten.each do |field|
+            opts[field] = result_of_attribute_or_method_call(field)
+          end if using.present?
 
-            formatter.format(opts)
-          end
-
-          # Meaningful name for formatter module in ancestor chain
-          def self.inspect
-            "Models::Formatter"
-          end
+          formatter.format(opts)
         end
 
-        include mod
+        # Meaningful name for formatter module in ancestor chain
+        def self.inspect
+          "Formatter"
+        end
       end
-    end
 
-    private
-
-    def result_of_attribute_or_method_call(field_name)
-      self[field_name.to_s].presence ||
-      (send(field_name) if respond_to?(field_name)).presence ||
-      ""
+      include mod
     end
+  end
+
+  private
+
+  def result_of_attribute_or_method_call(field_name)
+    self[field_name.to_s].presence ||
+    (send(field_name) if respond_to?(field_name)).presence ||
+    ""
   end
 end

--- a/app/models/footnote_description.rb
+++ b/app/models/footnote_description.rb
@@ -1,7 +1,7 @@
 require 'formatter'
 
 class FootnoteDescription < Sequel::Model
-  include Models::Formatter
+  include Formatter
 
   plugin :time_machine
   plugin :oplog, primary_key: [:footnote_description_period_sid,

--- a/app/models/goods_nomenclature_description.rb
+++ b/app/models/goods_nomenclature_description.rb
@@ -2,7 +2,7 @@ require 'time_machine'
 require 'formatter'
 
 class GoodsNomenclatureDescription < Sequel::Model
-  include Models::Formatter
+  include Formatter
 
   plugin :time_machine
   plugin :oplog, primary_key: [:goods_nomenclature_sid,
@@ -24,5 +24,3 @@ class GoodsNomenclatureDescription < Sequel::Model
     description
   end
 end
-
-

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -2,7 +2,7 @@ require 'formatter'
 require 'declarable'
 
 class Heading < GoodsNomenclature
-  include Model::Declarable
+  include Declarable
 
   plugin :oplog, primary_key: :goods_nomenclature_sid
   plugin :conformance_validator

--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -1,7 +1,7 @@
 require 'formatter'
 
 class MeasureComponent < Sequel::Model
-  include Models::Formatter
+  include Formatter
 
   plugin :time_machine
   plugin :oplog, primary_key: [:measure_sid, :duty_expression_id]

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -1,7 +1,7 @@
 require 'formatter'
 
 class MeasureCondition < Sequel::Model
-  include Models::Formatter
+  include Formatter
 
   plugin :time_machine
   plugin :national

--- a/app/models/measurement_unit_qualifier_description.rb
+++ b/app/models/measurement_unit_qualifier_description.rb
@@ -1,7 +1,7 @@
 require 'formatter'
 
 class MeasurementUnitQualifierDescription < Sequel::Model
-  include Models::Formatter
+  include Formatter
 
   plugin :oplog, primary_key: :measurement_unit_qualifier_code
   plugin :conformance_validator


### PR DESCRIPTION
We began getting a `ActiveSupport::Concern::MultipleIncludedBlocks`

rename modules:
- `Model::Declarable` -> `Declarable`
- `Models::Formatter` -> `Formatter`
