### PR TITLE
quota critical events issue (2015-01-02): extending primary key

### DIFF
--- a/app/models/quota_critical_event.rb
+++ b/app/models/quota_critical_event.rb
@@ -1,8 +1,8 @@
 class QuotaCriticalEvent < Sequel::Model
-  plugin :oplog, primary_key: :quota_definition_sid
+  plugin :oplog, primary_key: [:quota_definition_sid, :occurrence_timestamp]
   plugin :conformance_validator
 
-  set_primary_key [:quota_definition_sid]
+  set_primary_key [:quota_definition_sid, :occurrence_timestamp]
 
   many_to_one :quota_definition, key: :quota_definition_sid,
                                  primary_key: :quota_definition_sid

--- a/db/migrate/20150114110937_quota_critical_events_oplog_primary_key.rb
+++ b/db/migrate/20150114110937_quota_critical_events_oplog_primary_key.rb
@@ -1,0 +1,58 @@
+Sequel.migration do
+  up do
+    run %Q{
+      ALTER VIEW `quota_critical_events` AS 
+        select `quota_critical_events1`.`quota_definition_sid` AS `quota_definition_sid`,
+                `quota_critical_events1`.`occurrence_timestamp` AS `occurrence_timestamp`,
+                `quota_critical_events1`.`critical_state` AS `critical_state`,
+                `quota_critical_events1`.`critical_state_change_date` AS `critical_state_change_date`,
+                `quota_critical_events1`.`oid` AS `oid`,
+                `quota_critical_events1`.`operation` AS `operation`,
+                `quota_critical_events1`.`operation_date` AS `operation_date`
+        from 
+          `quota_critical_events_oplog` `quota_critical_events1`
+        where 
+          (
+            `quota_critical_events1`.`oid` in (
+              select max(`quota_critical_events2`.`oid`)
+              from `quota_critical_events_oplog` `quota_critical_events2`
+              where 
+                (
+                  `quota_critical_events1`.`quota_definition_sid` = `quota_critical_events2`.`quota_definition_sid`
+                  and `quota_critical_events1`.`occurrence_timestamp` = `quota_critical_events2`.`occurrence_timestamp`
+                )
+              order by `quota_critical_events2`.`oid` desc
+            ) and (
+              `quota_critical_events1`.`operation` <> 'D'
+            )
+          )
+    }
+  end
+
+  down do
+    run %Q{
+      ALTER VIEW `quota_critical_events` AS 
+        select `quota_critical_events1`.`quota_definition_sid` AS `quota_definition_sid`,
+                `quota_critical_events1`.`occurrence_timestamp` AS `occurrence_timestamp`,
+                `quota_critical_events1`.`critical_state` AS `critical_state`,
+                `quota_critical_events1`.`critical_state_change_date` AS `critical_state_change_date`,
+                `quota_critical_events1`.`oid` AS `oid`,
+                `quota_critical_events1`.`operation` AS `operation`,
+                `quota_critical_events1`.`operation_date` AS `operation_date`
+        from 
+          `quota_critical_events_oplog` `quota_critical_events1`
+        where 
+          (
+            `quota_critical_events1`.`oid` in (
+              select max(`quota_critical_events2`.`oid`)
+              from `quota_critical_events_oplog` `quota_critical_events2`
+              where 
+                (`quota_critical_events1`.`quota_definition_sid` = `quota_critical_events2`.`quota_definition_sid`)
+              order by `quota_critical_events2`.`oid` desc
+            ) and (
+              `quota_critical_events1`.`operation` <> 'D'
+            )
+          )
+    }
+  end
+end


### PR DESCRIPTION
Adding quota critical event occurrence timestamp to primary key, as there is some data with same `quota_definition_sid` but different `occurrence_timestamp` being added and deleted separately.