### PR TITLE
Budler-audit rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - A-Z fixed with move to serializers for the api
 - Increase the retries count and sleep time between failed downloads
 
+### Added
+- rake task for [budler-audit](https://github.com/rubysec/bundler-audit)
+
 ## release_878...release_903
 ### Changed
 - Upgraded Rails to 4.1.8 from 3.2.17

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ end
 group :development, :test do
   gem "pry-rails"
   gem "pry-nav"
+  gem "bundler-audit"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,9 @@ GEM
       sass (~> 3.0)
       terminal-table (~> 1.4)
     builder (3.2.2)
+    bundler-audit (0.3.1)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     capistrano (3.2.1)
       i18n
       rake (>= 10.0.0)
@@ -311,6 +314,7 @@ DEPENDENCIES
   aws-ses
   brakeman (= 1.7.0)
   builder
+  bundler-audit
   capistrano
   ci_reporter_rspec
   curb (= 0.8.6)

--- a/lib/tasks/bundler_audit.rake
+++ b/lib/tasks/bundler_audit.rake
@@ -1,0 +1,10 @@
+require "bundler/audit/cli"
+
+namespace :bundler do
+  desc "Updates the ruby-advisory-db and runs audit"
+  task :audit do
+    %w(update check).each do |command|
+      Bundler::Audit::CLI.start [command]
+    end
+  end
+end


### PR DESCRIPTION
Could be useful to add to travis to check for security issues in gems.

Runs with `bundle exec rake bundler:audit`