### PR TITLE
Fix bundler audit in production

### DIFF
--- a/lib/tasks/bundler_audit.rake
+++ b/lib/tasks/bundler_audit.rake
@@ -1,8 +1,7 @@
-require "bundler/audit/cli"
-
 namespace :bundler do
   desc "Updates the ruby-advisory-db and runs audit"
   task :audit do
+    require "bundler/audit/cli"
     %w(update check).each do |command|
       Bundler::Audit::CLI.start [command]
     end


### PR DESCRIPTION
When `bundle exec rake` runs it loads all of the rake tasks.

Because `bundler-audit` is only included in development and test environments, this causes all Rake tasks to fail on production.

Moving the require into the task fixes this.

cc @alext