### PR TITLE
Moving bundler_audit to codeclimate platform

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,10 @@
+---
+engines:
+  rubocop:
+    enabled: true
+  eslint:
+    enabled: true
+  csslint:
+    enabled: true
+  bundler-audit:
+    enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 cache: bundler
 env: GOVUK_APP_DOMAIN=test
@@ -13,7 +14,6 @@ script:
  - RAILS_ENV=test bundle exec rake db:create
  - RAILS_ENV=test bundle exec rake db:migrate
  - RAILS_ENV=test bundle exec rake spec
- - RAILS_ENV=test bundle exec rake bundler:audit
 rvm:
   - 2.2.1
 # Only build pushes to the master branch (and PRs)

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ end
 group :development, :test do
   gem "pry-rails", "~> 0.3"
   gem "pry-nav"
-  gem "bundler-audit", "~> 0.4"
   gem "brakeman", "~> 3.0", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,9 +58,6 @@ GEM
       sass (~> 3.0)
       terminal-table (~> 1.4)
     builder (3.2.2)
-    bundler-audit (0.4.0)
-      bundler (~> 1.2)
-      thor (~> 0.18)
     capistrano (3.4.0)
       i18n
       rake (>= 10.0.0)
@@ -353,7 +350,6 @@ DEPENDENCIES
   aws-ses (~> 0.6)
   brakeman (~> 3.0)
   builder (~> 3.2)
-  bundler-audit (~> 0.4)
   capistrano (~> 3.4)
   ci_reporter_rspec
   curb (~> 0.8)

--- a/lib/tasks/bundler_audit.rake
+++ b/lib/tasks/bundler_audit.rake
@@ -1,9 +1,0 @@
-namespace :bundler do
-  desc "Updates the ruby-advisory-db and runs audit"
-  task :audit do
-    require "bundler/audit/cli"
-    %w(update check).each do |command|
-      Bundler::Audit::CLI.start [command]
-    end
-  end
-end


### PR DESCRIPTION
Using codeclimate platform which also runs rubocop and other linters, as well as
bundler_audit so removing it from the travis scripts.

https://codeclimate.com/platform