### PR TITLE
treat geographical areas with code 2 as countries

### DIFF
--- a/app/controllers/api/v1/geographical_areas_controller.rb
+++ b/app/controllers/api/v1/geographical_areas_controller.rb
@@ -3,6 +3,7 @@ module Api
     class GeographicalAreasController < ApiController
       def countries
         @geographical_areas = GeographicalArea.eager(:geographical_area_descriptions)
+                                              .actual
                                               .countries
                                               .all
 

--- a/app/models/geographical_area.rb
+++ b/app/models/geographical_area.rb
@@ -1,4 +1,6 @@
 class GeographicalArea < Sequel::Model
+  COUNTRIES_CODES = ['0', '2'].freeze
+
   plugin :time_machine
   plugin :oplog, primary_key: :geographical_area_sid
   plugin :conformance_validator
@@ -51,7 +53,7 @@ class GeographicalArea < Sequel::Model
     end
 
     def countries
-      where(geographical_code: '0')
+      where(geographical_code: COUNTRIES_CODES)
     end
   end
 

--- a/spec/controllers/api/v1/geographical_areas_controller_spec.rb
+++ b/spec/controllers/api/v1/geographical_areas_controller_spec.rb
@@ -3,11 +3,25 @@ require 'rails_helper'
 describe Api::V1::GeographicalAreasController, "GET #countries" do
   render_views
 
-  let!(:geographical_area1) { create :geographical_area, :with_description, :country }
-  let!(:geographical_area2) { create :geographical_area, :with_description, :country }
+  let!(:geographical_area1) {
+    create :geographical_area,
+           :with_description,
+           :country
+  }
+  let!(:geographical_area2) {
+    create :geographical_area,
+           :with_description,
+           :country
+  }
+  let!(:geographical_area3) {
+    create :geographical_area,
+           :with_description,
+           geographical_code: "2"
+  }
 
   let(:pattern) {
     [
+      {id: String, description: String},
       {id: String, description: String},
       {id: String, description: String}
     ]
@@ -17,5 +31,63 @@ describe Api::V1::GeographicalAreasController, "GET #countries" do
     get :countries, format: :json
 
     expect(response.body).to match_json_expression pattern
+  end
+
+  it 'includes geographical areas with code 2' do
+    get :countries, format: :json
+
+    expect(response.body.to_s).to include(
+      geographical_area3.geographical_area_id
+    )
+  end
+
+  describe "machine timed" do
+    let!(:geographical_area1) {
+      create :geographical_area,
+             :with_description,
+             :country,
+             validity_end_date: "2015-12-31 00:00:00"
+    }
+    let!(:geographical_area2) {
+      create :geographical_area,
+             :with_description,
+             :country,
+             validity_end_date: "2015-12-01 00:00:00"
+    }
+    let!(:geographical_area3) {
+      create :geographical_area,
+             :with_description,
+             geographical_code: "2",
+             validity_end_date: "2015-12-31 00:00:00"
+    }
+
+    let(:pattern) {
+      [
+        { id: String, description: String },
+        { id: String, description: String }
+      ]
+    }
+
+    before do
+      get :countries,
+          format: :json,
+          as_of: "2015-12-04 00:00:00"
+    end
+
+    it "finds one area" do
+      expect(response.body).to match_json_expression pattern
+    end
+
+    it "includes area 1" do
+      expect(response.body.to_s).to include(
+        geographical_area1.geographical_area_id
+      )
+    end
+
+    it "doesn't include area 2" do
+      expect(response.body.to_s).to_not include(
+        geographical_area2.geographical_area_id
+      )
+    end
   end
 end


### PR DESCRIPTION
and ensure countries are being accessed through time machine when querying the api - so that it does not display expired countries. 

Fixes an issue with Serbia and Montenegro being displayed as one country not as separate countries, we needed to include geographical_code 2 as that is what serbia (and 4 other contries) was using.