### PR TITLE
[DO NOT MERGE] Update measure_presenter deduplication of VTS measure types

### DIFF
--- a/app/presenters/measure_presenter.rb
+++ b/app/presenters/measure_presenter.rb
@@ -19,7 +19,7 @@ class MeasurePresenter
                                   m.goods_nomenclature_sid != @declarable.goods_nomenclature_sid }
     end
 
-    if @collection.select{|m| m.measure_type_id == 'VTS'}.any?
+    if @collection.select{|m| m.measure_type_id == 'VTS'}.size > 1
       @collection.delete_if { |m| m.measure_type_id == 'VTS' &&
                                   m.goods_nomenclature_sid != @declarable.goods_nomenclature_sid }
     end

--- a/spec/integration/chief_transformer/custom_spec.rb
+++ b/spec/integration/chief_transformer/custom_spec.rb
@@ -236,12 +236,21 @@ describe 'CHIEF: Custom scenarios' do
   end
 
   describe 'Scenario: single CHIEF update contains MFCM Insert and Update operations' do
+    let!(:geographical_area)  { create :geographical_area, :erga_omnes, validity_start_date: DateTime.new(2010,2,22,12,27) }
     let!(:gono) { create :goods_nomenclature, :declarable, :with_indent,
                                              goods_nomenclature_sid: 97701,
                                              goods_nomenclature_item_id: '1104291710',
                                              producline_suffix: 80,
                                              validity_start_date: Date.new(2013,7,1),
                                              validity_end_date: nil}
+
+     let!(:tame) { create :tame,
+                          fe_tsmp: DateTime.new(2010,2,22,12,27),
+                          msrgp_code: 'VT',
+                          msr_type: 'Z',
+                          tty_code: 'B00',
+                          le_tsmp: nil }
+
     let!(:mfcm_insert) { create :mfcm, msrgp_code: 'VT',
                                 msr_type: 'Z',
                                 tty_code: 'B00',
@@ -263,15 +272,6 @@ describe 'CHIEF: Custom scenarios' do
                                 origin: "2013-07-11_KBT009(13192).txt",
                                 amend_indicator: 'U' }
 
-    let!(:geographical_area)  { create :geographical_area, :erga_omnes }
-    let!(:tame) {
-      create :tame,
-        fe_tsmp: DateTime.new(2010,2,22,12,27),
-        msrgp_code: 'VT',
-        msr_type: 'Z',
-        tty_code: 'B00',
-        le_tsmp: nil
-    }
 
 
     before {


### PR DESCRIPTION
There are measures:

2202901911
2202901919
2202901991
2202690199

Which have a VTS measure on 2202901900 the heading, but no additional
measure on the commodity code.

The deduplication code was removing the measure because the codes do not match,
however as there is only one VTS measure we should display it.