### PR TITLE
[Do not merge] Testing the removal of measure grouping

### DIFF
--- a/app/models/concerns/declarable.rb
+++ b/app/models/concerns/declarable.rb
@@ -39,11 +39,7 @@ module Declarable
         .order(Sequel.asc(:measures__geographical_area_id),
                Sequel.desc(:effective_start_date)),
         t1__measure_sid: :measures__measure_sid
-      ).group(:measures__measure_type_id,
-              :measures__geographical_area_sid,
-              :measures__measure_generating_regulation_id,
-              :measures__additional_code_type_id,
-              :measures__additional_code_id)
+      )
     }
 
     one_to_many :import_measures, key: {}, primary_key: {}, dataset: -> {


### PR DESCRIPTION
There is an issue where we are grouping measures which then means that
VTS measures are not displayed, when they then later go through the
MeasurePresenter and the measures from the parent is removed.