### PR TITLE
Add notes to chapter and section nodes of commodity response

### DIFF
--- a/app/views/api/v1/declarables/_declarable.json.rabl
+++ b/app/views/api/v1/declarables/_declarable.json.rabl
@@ -4,10 +4,18 @@ attributes :meursing_code
 
 child :section do
   attributes :title, :position, :numeral
+
+  node(:section_note, if: lambda { |section| section.section_note.present? }) do |section|
+    section.section_note.content
+  end
 end
 
 child :chapter do
   attributes :goods_nomenclature_item_id, :description, :formatted_description
+
+  node(:chapter_note, if: lambda {|chapter| chapter.chapter_note.present? }) do |chapter|
+    chapter.chapter_note.content
+  end
 end
 
 child :footnote do


### PR DESCRIPTION
#### What this PR does:

Adds `section_note` and `chapter_note` attributes to the section and chapter nodes from the response of the commodity show endpoint.

This change is necessary for the updates made in the frontend app.

#### Notes

I would like these new nodes to avoid the verbosity of having the parent relations in the name.. for example `note` instead of `section_note` since is already a child node of `section` but the frontend code already defined these name, so in order to keep it simple I choose to just use the same names.